### PR TITLE
System info parity tweaks

### DIFF
--- a/ci-mega.json
+++ b/ci-mega.json
@@ -74,6 +74,15 @@
       "execute_command": "{{ .Vars }} exec sudo -E -S bash '{{ .Path }}'"
     },
     {
+      "type": "file",
+      "source": "packer-assets/system-info-commands.yml",
+      "destination": "/var/tmp/system-info-commands.yml"
+    },
+    {
+      "type": "shell",
+      "inline": "chmod 0644 /var/tmp/system-info-commands.yml"
+    },
+    {
       "type": "chef-solo",
       "config_template": "chef-solo.rb.tmpl",
       "cookbook_paths": [

--- a/ci-mega.yml
+++ b/ci-mega.yml
@@ -76,6 +76,11 @@ provisioners:
   - TRAVIS_COOKBOOKS_BRANCH={{ user `travis_cookbooks_branch` }}
   - TRAVIS_COOKBOOKS_SHA={{ user `travis_cookbooks_sha` }}
   execute_command: "{{ .Vars }} exec sudo -E -S bash '{{ .Path }}'"
+- type: file
+  source: packer-assets/system-info-commands.yml
+  destination: "/var/tmp/system-info-commands.yml"
+- type: shell
+  inline: chmod 0644 /var/tmp/system-info-commands.yml
 - type: chef-solo
   config_template: chef-solo.rb.tmpl
   cookbook_paths:

--- a/cookbooks/travis_ci_mega/attributes/default.rb
+++ b/cookbooks/travis_ci_mega/attributes/default.rb
@@ -6,6 +6,9 @@ default['travis_ci_mega']['prerequisite_packages'] = %w(
   wget
 )
 
+override['travis_system_info']['commands_file'] = \
+  '/var/tmp/system-info-commands.yml'
+
 override['travis_php']['multi']['versions'] = %w(
   5.6.15
   5.5.30

--- a/packer-assets/generate-ssh-host-keys
+++ b/packer-assets/generate-ssh-host-keys
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 # http://anonscm.debian.org/cgit/pkg-ssh/openssh.git/tree/debian/openssh-server.postinst?id=c77724ca2355dec905cfa1e18930c79e32db2d4e

--- a/packer-assets/minimal-system-info-commands.yml
+++ b/packer-assets/minimal-system-info-commands.yml
@@ -1,10 +1,16 @@
 commands:
+  linux:
+    - { command: date -u, name: Build image provisioning date and time }
+    - { command: lsb_release -a, name: Operating System Details }
+    - { command: uname -r, name: Linux Version }
   common:
-    - { command: docker version, name: Docker version }
-    - { command: git --version, name: Git version }
-    - { command: gcc --version, name: GCC version }
-    - { command: clang --version, name: LLVM version }
+    - { command: git --version, name: git version }
+    - { command: bash --version, name: bash version }
+    - { command: gcc --version, name: gcc version }
+    - { command: docker version, name: docker version }
+    - { command: clang --version, name: clang version }
     - { command: jq --version, name: jq version }
+    - { command: bats --version, name: bats version }
     - { command: gimme --version, name: gimme version }
     - { command: nvm --version, name: nvm version }
     - { command: perlbrew --version, name: perlbrew version }
@@ -13,11 +19,6 @@ commands:
     - { command: rvm --version, name: rvm version }
     - { command: ruby --version, name: default ruby version }
     - { command: python --version, name: default python version }
-
-  linux:
-    - command: date
-      name: Build image provisioning date and time
-    - command: lsb_release -a
-      name: Operating System Details
-    - command: uname -r
-      name: Linux Version
+    - command: rvm list
+      name: Pre-installed Ruby versions
+      pipe: env GREP_COLORS='mt=01;32' egrep -o '(j?ruby|rbx|ree)-[^ ]+' | sort | uniq

--- a/packer-assets/ssh-keygen.init
+++ b/packer-assets/ssh-keygen.init
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 ### BEGIN INIT INFO

--- a/packer-assets/system-info-commands.yml
+++ b/packer-assets/system-info-commands.yml
@@ -1,0 +1,101 @@
+commands:
+  linux:
+    - { command: date -u, name: Build image provisioning date and time }
+    - { command: lsb_release -a, name: Operating System Details }
+    - { command: uname -r, name: Linux Version }
+  osx:
+    - { command: date, name: Build image provisioning date and time }
+    - { command: sw_vers, name: Operating System Details }
+    - { command: uname -r, name: Darwin Version }
+  common:
+    - { command: git --version, name: git version }
+    - { command: bash --version, name: bash version }
+    - { command: gcc --version, name: gcc version }
+    - { command: docker version, name: docker version }
+    - { command: clang --version, name: clang version }
+    - { command: jq --version, name: jq version }
+    - { command: bats --version, name: bats version }
+    - { command: gimme --version, name: gimme version }
+    - { command: nvm --version, name: nvm version }
+    - { command: perlbrew --version, name: perlbrew version }
+    - { command: psql --version, name: postgresql client version }
+    - { command: phpenv --version, name: phpenv version }
+    - { command: rvm --version, name: rvm version }
+    - { command: ruby --version, name: default ruby version }
+    - { command: python --version, name: default python version }
+    - command: rvm list
+      name: Pre-installed Ruby versions
+      pipe: env GREP_COLORS='mt=01;32' egrep -o '(j?ruby|rbx|ree)-[^ ]+' | sort | uniq
+    - command: nvm list
+      name: Pre-installed Node.js versions
+      pipe: env GREP_COLORS='mt=01;32' egrep -o '(iojs-)?v[0-9\.]+' | sort | uniq
+    - { command: gimme -l, name: Pre-installed Go versions }
+    - { command: mysql --version, name: mysql version }
+    - command: dpkg -l
+      name: Pre-installed PostgreSQL versions
+      pipe: awk '$2 ~ /^postgresql-[0-9]+\.[0-9]+$/ {print $3}' | grep -E --only '^[^-]+'
+    - command: redis-server --version
+      name: Redis version
+      pipe: perl -n -e '/v=([\d\.]+)/ && {print "redis-server $1\n"}'
+    - { command: riak version, name: riak version }
+    - command: mongod --version
+      name: MongoDB version
+      pipe: perl -n -e '/version v(.*)$/ && { print "MongoDB $1\n" }'
+    - command: couchdb -V
+      name: CouchDB version
+      pipe: perl -n -e '/CouchDB ([\d\.]+)/ && {print "couchdb $1\n"}'
+    - pre: service neo4j restart
+      name: Neo4j version
+      port: 7474
+      command: 'curl http://localhost:7474/db/data 2>/dev/null'
+      pipe: perl -ne '/neo4j_version.*?([0-9\.]+)/ && print $1'
+      post: service neo4j stop
+    - pre: sudo service cassandra restart
+      name: Cassandra version
+      port: 9042
+      command: /usr/local/cassandra/bin/nodetool version
+      pipe: perl -ne '/ReleaseVersion.*?([0-9\.]+)/ && print $1'
+      post: sudo service cassandra stop; sudo rm -rf /var/lib/cassandra/*"
+    - pre: sudo service rabbitmq-server restart
+      name: RabbitMQ Version
+      port: 5672
+      command: sudo rabbitmqctl status
+      pipe: "awk -F \\\" '/\\\"RabbitMQ\\\"/ {print $4}' "
+      post: sudo service rabbitmq-server stop >/dev/null
+    - pre: sudo service elasticsearch restart
+      name: ElasticSearch version
+      port: 9200
+      command: 'curl localhost:9200 2>/dev/null'
+      pipe: "awk -F\\\" '/number/ { print $4 }'"
+      post: sudo service elasticsearch stop >/dev/null
+    - command: ls -lad /usr/local/sphinx-*
+      name: Installed Sphinx versions
+      pipe: perl -n -e '/sphinx-([^\/]+)/ && {print "$1"}'
+    - command: ls -l /usr/local/bin/searchd
+      name: Default Sphinx version
+      pipe: perl -n -e '/sphinx-([^\/]+)/ && {print "$1\n"}'
+    - command: ls -d /usr/local/firefox-*
+      name: Installed Firefox version
+      pipe: awk -F- '{print "firefox", $2}'
+    - command: /usr/local/phantomjs/bin/phantomjs --version
+      name: PhantomJS version
+    - command: grep Pkg.Revision /usr/local/android-sdk/tools/source.properties
+      name: Android SDK Tools Version
+      pipe: awk -F= '{ print $2 }'
+    - command: android list sdk --no-ui --all --extended
+      name: List of Android SDK components that can be specified in .travis.yml
+      pipe: "awk -F\\\" '/^id/ {print $2}' | sort"
+    - command: 'which android && echo -e "\033[33;1mSee http://docs.travis-ci.com/user/languages/android/#How-to-install-Android-SDK-components\033[0m"'
+    - { command: ant -version, name: ant version }
+    - { command: mvn -version, name: mvn version }
+    - { command: gradle -version, name: gradle version }
+    - command: kerl list installations
+    - command: kiex list
+    - command: rebar --version
+    - { command: ls -l /usr/local/ghc, name: ghc installations }
+    - command: lein1 version
+    - command: lein2 version
+    - command: lein version
+    - command: perlbrew list
+    - command: phpenv versions
+    - command: composer --version

--- a/runtests
+++ b/runtests
@@ -3,9 +3,22 @@ set -o errexit
 
 unset GEM_PATH
 
-for f in $(git ls-files | grep -v / | grep '.json$') ; do
+for f in $(git ls-files '*.json' | grep -v /) ; do
   echo -en "$f "
   diff -q $f <(jq . < $f)
+  echo "✓"
+done
+
+for f in $(git ls-files '*.yml') ; do
+  echo -en "$f "
+  ruby -ryaml -e "YAML.load_file('$f')"
+  echo "✓"
+done
+
+for f in $(git grep -l '^#!/usr/bin/env bash') ; do
+  if [[ ! -x "$f" ]] ; then continue ; fi
+  echo -en "$f "
+  bash -n $f
   echo "✓"
 done
 


### PR DESCRIPTION
- ensure all minimal commands are included in mega
- add `bats --version` to both minimal and mega
- add extra assertions for YAML and bash file validity