### PR TITLE
Ensure tags on googlecompute builders

### DIFF
--- a/ci-amethyst.yml
+++ b/ci-amethyst.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - amethyst
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-android.yml
+++ b/ci-android.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - android
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-connie.yml
+++ b/ci-connie.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - connie
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-erlang.yml
+++ b/ci-erlang.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - erlang
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-garnet.yml
+++ b/ci-garnet.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - garnet
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-go.yml
+++ b/ci-go.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - go
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-haskell.yml
+++ b/ci-haskell.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - haskell
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-jvm.yml
+++ b/ci-jvm.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - jvm
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-nodejs.yml
+++ b/ci-nodejs.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - nodejs
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-perl.yml
+++ b/ci-perl.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - perl
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-php.yml
+++ b/ci-php.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - php
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-python.yml
+++ b/ci-python.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - python
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-ruby.yml
+++ b/ci-ruby.yml
@@ -26,6 +26,7 @@ builders:
   tags:
   - ci
   - ruby
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/ci-sugilite.yml
+++ b/ci-sugilite.yml
@@ -24,6 +24,7 @@ builders:
   tags:
   - ci
   - sugilite
+  - travis-ci-packer-templates
 provisioners:
 - type: shell
   inline: sleep 10

--- a/play.yml
+++ b/play.yml
@@ -27,6 +27,7 @@ builders:
   disk_size: 15
   tags:
   - play
+  - travis-ci-packer-templates
 - type: docker
   name: docker
   ssh_pty: true

--- a/tmate-edge.yml
+++ b/tmate-edge.yml
@@ -43,6 +43,7 @@ builders:
   machine_type: n1-standard-4
   tags:
   - tmate-edge
+  - travis-ci-packer-templates
 provisioners:
 - type: shell
   inline: sleep 10

--- a/worker.yml
+++ b/worker.yml
@@ -48,6 +48,7 @@ builders:
   machine_type: n1-standard-4
   tags:
   - worker
+  - travis-ci-packer-templates
 provisioners:
 - type: shell
   inline: sleep 10


### PR DESCRIPTION
such that all templates with a googlecompute builder include an instance tag of `travis-ci-packer-templates` so that SSH communication is allowed.