### PR TITLE
Add ruby 2.3.1 to preinstalled ruby versions

### DIFF
--- a/cookbooks/travis_ci_ruby/attributes/default.rb
+++ b/cookbooks/travis_ci_ruby/attributes/default.rb
@@ -11,6 +11,7 @@ override['rvm']['rubies'] = [
   2.1.4
   2.1.5
   2.2.5
+  2.3.1
 ).map { |name| { name: name, arguments: '--binary --fuzzy' } })
 
 override['rvm']['gems'] = %w(
@@ -20,7 +21,8 @@ override['rvm']['gems'] = %w(
 override['rvm']['aliases'] = {
   '2.0' => 'ruby-2.0.0',
   '2.1' => 'ruby-2.1.5',
-  '2.2' => 'ruby-2.2.5'
+  '2.2' => 'ruby-2.2.5',
+  '2.3' => 'ruby-2.3.1'
 }
 override['java']['alternate_versions'] = %w(
   openjdk6


### PR DESCRIPTION
Also, set up an alias for 2.3 to point to 2.3.1 matching other minor versions. 

This should speed up build times for anyone using the latest stable ruby version.