### PR TITLE
Open up ssh client restrictions to `10.*`

### DIFF
--- a/cookbooks/travis_internal_base/attributes/default.rb
+++ b/cookbooks/travis_internal_base/attributes/default.rb
@@ -1,5 +1,5 @@
-override['openssh']['client']['10.10.*']['strict_host_key_checking'] = 'no'
-override['openssh']['client']['10.10.*']['user_known_hosts_file'] = '/dev/null'
+override['openssh']['client']['10.*']['strict_host_key_checking'] = 'no'
+override['openssh']['client']['10.*']['user_known_hosts_file'] = '/dev/null'
 override['openssh']['server']['allow_tcp_forwarding'] = 'no'
 override['openssh']['server']['challenge_response_authentication'] = 'no'
 override['openssh']['server']['listen_address'] = %w(0.0.0.0:22 [::]:22)


### PR DESCRIPTION
since we use `10.10.` in some places and `10.[234]` in others