### PR TITLE
Remove amazon-ebs builder definition for internal-nat

### DIFF
--- a/internal-nat.yml
+++ b/internal-nat.yml
@@ -9,20 +9,6 @@ variables:
   subnet_id: "{{ env `TRAVIS_SUBNET_ID` }}"
   vpc_id: "{{ env `TRAVIS_VPC_ID` }}"
 builders:
-- type: amazon-ebs
-  access_key: "{{ user `aws_access_key` }}"
-  secret_key: "{{ user `aws_secret_key` }}"
-  region: us-east-1
-  source_ami: ami-8e0b9499
-  ami_name: nat {{ isotime "2006-01-02 15:04:06" | clean_ami_name }}
-  instance_type: t2.micro
-  ssh_username: ubuntu
-  ami_virtualization_type: hvm
-  tags:
-    role: vpn
-  associate_public_ip_address: true
-  subnet_id: "{{ user `subnet_id` }}"
-  vpc_id: "{{ user `vpc_id` }}"
 - type: googlecompute
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"


### PR DESCRIPTION
as we use the amazon NAT AMI