### PR TITLE
Add Ruby 2.3.3 to preinstalled ruby versions

### DIFF
--- a/cookbooks/travis_ci_ruby/attributes/default.rb
+++ b/cookbooks/travis_ci_ruby/attributes/default.rb
@@ -17,7 +17,7 @@ override['rvm']['aliases'] = {
   '2.0' => 'ruby-2.0.0',
   '2.1' => 'ruby-2.1.5',
   '2.2' => 'ruby-2.2.5',
-  '2.3' => 'ruby-2.3.1'
+  '2.3' => 'ruby-2.3.3'
 }
 override['java']['alternate_versions'] = %w(
   openjdk6

--- a/cookbooks/travis_ci_ruby/attributes/default.rb
+++ b/cookbooks/travis_ci_ruby/attributes/default.rb
@@ -6,6 +6,7 @@ override['rvm']['rubies'] = %w(
   2.1.10
   2.2.5
   2.3.1
+  2.3.3
 ).map { |name| { name: name, arguments: '--binary --fuzzy' } }
 
 override['rvm']['gems'] = %w(


### PR DESCRIPTION
This also makes 2.3.3 the default Ruby 2.3. 