### PR TITLE
Include options for bulk apt packages installation

### DIFF
--- a/cookbooks/travis_packer_templates/recipes/default.rb
+++ b/cookbooks/travis_packer_templates/recipes/default.rb
@@ -56,8 +56,9 @@ ruby_block 'write job-board registration bits' do
 end
 
 Array(node['travis_packer_templates']['packages']).each_slice(10) do |slice|
-  package slice do
+  apt_package slice do
     retries 2
-    action [:install, :upgrade]
+    options '--no-install-recommends --no-install-suggests'
+    action %i(install upgrade)
   end
 end


### PR DESCRIPTION
so that `--no-install-recommends` and `--no-install-suggests` keep unexpected
dependencies from coming along for the ride.   This is specifically intended to
prevent the installation of `chromium-browser` from pulling in `dbus`, which
also pulls in `systemd`, which is very much incompatible with the dockerized
Ubuntu 14.04 we use.