### PR TITLE
Shorten the instance id when generating hostname

### DIFF
--- a/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
+++ b/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
@@ -20,6 +20,7 @@ main() {
   curl -sSL 'http://169.254.169.254/latest/meta-data/instance-id' \
     >"${RUNDIR}/instance-id"
   instance_id="$(cat "${RUNDIR}/instance-id")"
+  instance_id="${instance_id:0:9}"
 
   curl -sSL 'http://169.254.169.254/latest/meta-data/local-ipv4' \
     >"${RUNDIR}/instance-ipv4"


### PR DESCRIPTION
so that we don't get hit with

```
hostname: name too long
2017-01-09 16:10:59,387 - util.py[WARNING]: Failed running /var/lib/cloud/scripts/per-instance/10-set-hostname-from-template [1]
```