### PR TITLE
Upgrade to apt 1.2.0

### DIFF
--- a/packer-scripts/pre-chef-bootstrap
+++ b/packer-scripts/pre-chef-bootstrap
@@ -49,11 +49,11 @@ __install_packages() {
 __upgrade_apt() {
   curl -sSL https://packagecloud.io/install/repositories/computology/apt-backport/script.deb.sh \
     | bash
-  apt-get update
-  apt-get install apt=1.2.10
-  apt-get clean
+  apt-get update -yqq
+  apt-get install -yqq apt=1.2.10
+  apt-get clean -yqq
   rm -rf /var/lib/apt/lists
-  apt-get update
+  apt-get update -yqq
 }
 
 __setup_sshd() {

--- a/packer-scripts/pre-chef-bootstrap
+++ b/packer-scripts/pre-chef-bootstrap
@@ -12,6 +12,7 @@ main() {
     __disable_ipv6
   fi
   __install_packages
+  __upgrade_apt
   __setup_sshd
   __setup_travis_user
 }
@@ -43,6 +44,16 @@ __install_packages() {
     wget \
     python \
     ${APT_GET_INSTALL_PRE_CHEF}
+}
+
+__upgrade_apt() {
+  curl -sSL https://packagecloud.io/install/repositories/computology/apt-backport/script.deb.sh \
+    | bash
+  apt-get update
+  apt-get install apt=1.2.10
+  apt-get clean
+  rm -rf /var/lib/apt/lists
+  apt-get update
 }
 
 __setup_sshd() {


### PR DESCRIPTION
for more [reliable behavior with packagecloud repos AND MORE](https://blog.packagecloud.io/eng/2016/10/17/apt-by-hash-backport-ubuntu-trusty-precise/)!