### PR TITLE
Enable oraclejdk8 on cookiecat

### DIFF
--- a/cookbooks/lib/features/basic_spec.rb
+++ b/cookbooks/lib/features/basic_spec.rb
@@ -278,7 +278,6 @@ describe 'git installation' do
 end
 
 describe command('heroku version') do
-  its(:stdout) { should match(%r{^heroku-toolbelt\/\d}) }
   its(:stdout) { should match(%r{^heroku-cli\/\d}) }
 end
 

--- a/cookbooks/travis_ci_cookiecat/attributes/default.rb
+++ b/cookbooks/travis_ci_cookiecat/attributes/default.rb
@@ -61,8 +61,11 @@ override['android-sdk']['license']['default_answer'] = 'y'
 override['android-sdk']['scripts']['owner'] = 'travis'
 override['android-sdk']['scripts']['group'] = 'travis'
 
-override['travis_java']['default_version'] = 'openjdk8'
-override['travis_java']['alternate_versions'] = %w[openjdk7]
+override['travis_java']['default_version'] = 'oraclejdk8'
+override['travis_java']['alternate_versions'] = %w[
+  openjdk7
+  openjdk8
+]
 
 override['leiningen']['home'] = '/home/travis'
 override['leiningen']['user'] = 'travis'


### PR DESCRIPTION
plus get the alternate versions more in line with garnet/sugilite.

- [x] [packer-build succeeds](https://travis-ci.org/travis-infrastructure/packer-build/builds/244607475)