### PR TITLE
Add some Qt4 packages to most trusty stacks

### DIFF
--- a/packer-assets/ubuntu-trusty-ci-amethyst-docker-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-amethyst-docker-packages.txt
@@ -1,4 +1,8 @@
 chromium-browser
+libqt4-opengl
+libqt4-opengl-dev
+libqtwebkit-dev
+libqtwebkit4
 scons
 x11-utils
 x11-xserver-utils

--- a/packer-assets/ubuntu-trusty-ci-amethyst-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-amethyst-packages.txt
@@ -269,6 +269,10 @@ libpython3-stdlib:amd64
 libpython3.4-minimal:amd64
 libpython3.4-stdlib:amd64
 libqt4-dev
+libqt4-opengl
+libqt4-opengl-dev
+libqtwebkit-dev
+libqtwebkit4
 libreadline-dev
 libreadline6
 libreadline6:amd64

--- a/packer-assets/ubuntu-trusty-ci-cookiecat-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-cookiecat-packages.txt
@@ -269,6 +269,10 @@ libpython3-stdlib:amd64
 libpython3.4-minimal:amd64
 libpython3.4-stdlib:amd64
 libqt4-dev
+libqt4-opengl
+libqt4-opengl-dev
+libqtwebkit-dev
+libqtwebkit4
 libreadline-dev
 libreadline6
 libreadline6:amd64

--- a/packer-assets/ubuntu-trusty-ci-garnet-docker-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-garnet-docker-packages.txt
@@ -2,6 +2,10 @@ ant
 ant-contrib
 chromium-browser
 ivy
+libqt4-opengl
+libqt4-opengl-dev
+libqtwebkit-dev
+libqtwebkit4
 scons
 x11-utils
 x11-xserver-utils

--- a/packer-assets/ubuntu-trusty-ci-garnet-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-garnet-packages.txt
@@ -272,6 +272,10 @@ libpython3-stdlib:amd64
 libpython3.4-minimal:amd64
 libpython3.4-stdlib:amd64
 libqt4-dev
+libqt4-opengl
+libqt4-opengl-dev
+libqtwebkit-dev
+libqtwebkit4
 libreadline-dev
 libreadline6
 libreadline6:amd64

--- a/packer-assets/ubuntu-trusty-ci-sugilite-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-sugilite-packages.txt
@@ -272,6 +272,10 @@ libpython3-stdlib:amd64
 libpython3.4-minimal:amd64
 libpython3.4-stdlib:amd64
 libqt4-dev
+libqt4-opengl
+libqt4-opengl-dev
+libqtwebkit-dev
+libqtwebkit4
 libreadline-dev
 libreadline6
 libreadline6:amd64


### PR DESCRIPTION
for ensuring things like Capybara Webkit can work correctly by default.

- [x] amethyst builds
- [x] garnet builds
- [x] sugilite builds