### PR TITLE
Patch redis-server init script on container-based

### DIFF
--- a/cookbooks/travis_ci_amethyst/recipes/default.rb
+++ b/cookbooks/travis_ci_amethyst/recipes/default.rb
@@ -57,4 +57,9 @@ include_recipe 'travis_build_environment::google_chrome'
 include_recipe 'travis_build_environment::firefox'
 include_recipe 'travis_phantomjs'
 include_recipe 'travis_phantomjs::2'
+
+if node['travis_packer_templates']['env']['PACKER_BUILDER_TYPE'] == 'docker'
+  include_recipe 'travis_packer_templates::container_based_patches'
+end
+
 include_recipe 'travis_system_info'

--- a/cookbooks/travis_ci_garnet/recipes/default.rb
+++ b/cookbooks/travis_ci_garnet/recipes/default.rb
@@ -60,6 +60,11 @@ include_recipe 'travis_build_environment::google_chrome'
 include_recipe 'travis_build_environment::firefox'
 include_recipe 'travis_phantomjs'
 include_recipe 'travis_phantomjs::2'
+
+if node['travis_packer_templates']['env']['PACKER_BUILDER_TYPE'] == 'docker'
+  include_recipe 'travis_packer_templates::container_based_patches'
+end
+
 include_recipe 'travis_system_info'
 
 # HACK: force removal of ~/.pearrc until a decision is reached on if they are

--- a/cookbooks/travis_packer_templates/files/default/etc-init.d-redis-server.patch
+++ b/cookbooks/travis_packer_templates/files/default/etc-init.d-redis-server.patch
@@ -1,0 +1,13 @@
+--- a/etc/init.d/redis-server
++++ b/etc/init.d/redis-server
+@@ -55,7 +55,9 @@
+ 
+ 	if [ -n "$ULIMIT" ]
+ 	then
+-		ulimit -n $ULIMIT
++		# NOTE: patched by github.com/travis-ci/packer-templates
++		#       when docker execution environment detected.
++		: no ulimit
+ 	fi
+ 
+ 	Run_parts pre-up

--- a/cookbooks/travis_packer_templates/recipes/container_based_patches.rb
+++ b/cookbooks/travis_packer_templates/recipes/container_based_patches.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Cookbook Name:: travis_packer_templates
+# Recipe:: container_based_patches
+#
+# Copyright 2017, Travis CI GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+redis_server_patch_path = ::File.join(
+  Chef::Config[:file_cache_path], 'etc-init.d-redis-server.patch'
+)
+
+cookbook_file redis_server_patch_path do
+  only_if { ::File.exist?('/etc/init.d/redis-server') }
+end
+
+execute "patch -p1 <#{redis_server_patch_path}" do
+  cwd '/'
+  only_if { ::File.exist?('/etc/init.d/redis-server') }
+end


### PR DESCRIPTION
Restricted to amethyst and garnet, intended to replace the logic being
done in travis-build (via travis-ci/travis-build#1085).

Signed-off-by: Carmen Andoh <carmen@travis-ci.org>

- [x] amethyst docker builds
- [x] garnet docker builds