### PR TITLE
Use sugilite for language: generic

### DIFF
--- a/cookbooks/travis_ci_amethyst/attributes/default.rb
+++ b/cookbooks/travis_ci_amethyst/attributes/default.rb
@@ -71,8 +71,8 @@ override['travis_build_environment']['nodejs_default'] = node_versions.max
 override['travis_build_environment']['pythons'] = []
 
 rubies = %w[
-  2.3.3
-  2.4.0
+  2.2.7
+  2.4.1
 ]
 
 override['travis_build_environment']['default_ruby'] = rubies.reject { |n| n =~ /jruby/ }.max

--- a/cookbooks/travis_ci_connie/attributes/default.rb
+++ b/cookbooks/travis_ci_connie/attributes/default.rb
@@ -31,8 +31,8 @@ override['travis_system_info']['commands_file'] = \
   '/var/tmp/connie-system-info-commands.yml'
 
 rubies = %w[
-  2.3.3
-  2.4.0
+  2.2.7
+  2.4.1
 ]
 
 override['travis_build_environment']['default_ruby'] = rubies.max
@@ -62,7 +62,6 @@ override['travis_packer_templates']['job_board']['features'] = %w[
 override['travis_packer_templates']['job_board']['languages'] = %w[
   __connie__
   bash
-  generic
   minimal
   sh
   shell

--- a/cookbooks/travis_ci_cookiecat/attributes/default.rb
+++ b/cookbooks/travis_ci_cookiecat/attributes/default.rb
@@ -35,8 +35,8 @@ override['travis_build_environment']['nodejs_aliases'] = {}
 override['travis_build_environment']['nodejs_default_modules'] = []
 
 rubies = %w[
-  2.3.3
-  2.4.0
+  2.2.7
+  2.4.1
 ]
 
 override['travis_build_environment']['default_ruby'] = rubies.max

--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -84,9 +84,9 @@ pythons.each do |full_name|
 end
 
 rubies = %w[
-  2.2.6
-  2.3.3
-  2.4.0
+  2.2.7
+  2.3.4
+  2.4.1
 ]
 
 override['travis_build_environment']['default_ruby'] = rubies.reject { |n| n =~ /jruby/ }.max

--- a/cookbooks/travis_ci_sugilite/attributes/default.rb
+++ b/cookbooks/travis_ci_sugilite/attributes/default.rb
@@ -147,11 +147,11 @@ override['python']['pip']['packages']['3.2'] = []
 override['python']['pip']['packages']['3.3'] = []
 
 rubies = %w[
-  jruby-9.1.6.0
+  jruby-9.1.9.0
   2.1.10
-  2.2.6
-  2.3.3
-  2.4.0
+  2.2.7
+  2.3.4
+  2.4.1
 ]
 
 override['travis_build_environment']['default_ruby'] = rubies.reject { |n| n =~ /jruby/ }.max
@@ -234,6 +234,7 @@ override['travis_packer_templates']['job_board']['languages'] = %w[
   default
   elixir
   erlang
+  generic
   go
   groovy
   haskell


### PR DESCRIPTION
and ensure dpl-compatible ruby is available on all stacks

- [x] [ci-amethyst passes](https://travis-ci.org/travis-infrastructure/packer-build/builds/249223537)
- [x] [ci-cookiecat passes](https://travis-ci.org/travis-infrastructure/packer-build/builds/249223549)
- [x] [ci-connie passes](https://travis-ci.org/travis-infrastructure/packer-build/builds/249223540)
- [x] [ci-garnet passes](https://travis-ci.org/travis-infrastructure/packer-build/builds/249223554)
- [x] [ci-sugilite passes](https://travis-ci.org/travis-infrastructure/packer-build/builds/249223569)