### PR TITLE
Use the latest patch release of each Python version

### DIFF
--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -60,7 +60,7 @@ override['travis_build_environment']['nodejs_default'] = node_versions.max
 
 pythons = %w[
   2.7.13
-  3.5.2
+  3.5.3
 ]
 
 # Reorder pythons so that default python2 and python3 come first

--- a/cookbooks/travis_ci_sugilite/attributes/default.rb
+++ b/cookbooks/travis_ci_sugilite/attributes/default.rb
@@ -117,9 +117,9 @@ override['travis_build_environment']['nodejs_default'] = node_versions.max
 pythons = %w[
   2.7.13
   3.3.6
-  3.4.5
-  3.5.2
-  3.6.0
+  3.4.6
+  3.5.3
+  3.6.1
   pypy2-5.6.0
 ]
 


### PR DESCRIPTION
I'll also open a PR against travis-cookbooks to update the defaults there.

One thing I did spot was that garnet uses 2.7.x and 3.5.x, whereas travis-cookbooks uses 2.7.x and 3.6.x:
https://github.com/travis-ci/packer-templates/blob/d5d651576e65335033f3e4c7b836dc60fbc21903/cookbooks/travis_ci_garnet/attributes/default.rb#L62-L63
https://github.com/travis-ci/travis-cookbooks/blob/023aa70f0ea08fb475a54906b1b0bf03414ea526/cookbooks/travis_build_environment/attributes/default.rb#L77-L78

Is this intentional? For the environments where only one of each of python2 and python 3 are installed,  should the versions be consistent?