### PR TITLE
Make GCE_ACCOUNT_FILE_B64_BZ2 optional in packer-build-install

### DIFF
--- a/bin/packer-build-install
+++ b/bin/packer-build-install
@@ -5,9 +5,12 @@ set -o errexit
 cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
 
 mkdir -p tmp/
-echo "${GCE_ACCOUNT_FILE_B64_BZ2}" \
-  | base64 -d \
-  | bunzip2 >tmp/gce.json
+
+if [[ -n "${GCE_ACCOUNT_FILE_B64_BZ2}" ]]; then
+  echo "${GCE_ACCOUNT_FILE_B64_BZ2}" \
+    | base64 -d \
+    | bunzip2 >tmp/gce.json
+fi
 
 if [[ "$(packer version 2>/dev/null)" != "Packer v1.0.0" ]]; then
   make install-packer


### PR DESCRIPTION
It isn't set during pull requests (since it's a secure variable) so was previously causing the Travis run for PRs to fail, even though it isn't actually needed for the tests to run.

Fixes #456.