### PR TITLE
Ensure the /home/travis/bin directory exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ provisioning process.  The steps executed include:
 - ensure the `/home/travis/.ssh/authorized_keys` file exists
 - add `/var/tmp/*_rsa.pub` to `/home/travis/.ssh/authorized_keys`
 - ensure `/home/travis/.ssh/authorized_keys` perms are `0600`
+- ensure the `/home/travis/bin` dir exists
 
 #### cloning travis-cookbooks
 

--- a/cookbooks/lib/features/basic_spec.rb
+++ b/cookbooks/lib/features/basic_spec.rb
@@ -599,6 +599,16 @@ describe user('travis') do
   it { should have_login_shell '/bin/bash' }
 end
 
+describe file('/home/travis/bin') do
+  it { should be_directory }
+  it 'is writable' do
+    File.open('/home/travis/bin/.travis-write-test', 'w') do |f|
+      f.puts Time.now.utc.to_s
+    end
+    expect(File.read('/home/travis/bin/.travis-write-test')).to_not be_empty
+  end
+end
+
 def test_txt
   Support.tmpdir.join('test.txt')
 end

--- a/packer-scripts/pre-chef-bootstrap
+++ b/packer-scripts/pre-chef-bootstrap
@@ -82,6 +82,9 @@ __setup_travis_user() {
   __setup_sudoers
   __setup_travis_ssh
 
+  # Save users having to create this directory at runtime (it's already on PATH)
+  mkdir -p /home/travis/bin
+
   mkdir -p /opt
   chmod 0755 /opt
   chown -R travis:travis /home/travis /opt


### PR DESCRIPTION
So that users can download standalone binaries directly into it, without needing `mkdir $HOME/bin` boilerplate (it's already on `PATH`).

Fixes #463.