### PR TITLE
Trigger image builds for the virtualenv site-packages fix

### DIFF
--- a/ci-amethyst.yml
+++ b/ci-amethyst.yml
@@ -1,5 +1,5 @@
 ---
-description: Travis CI Amethyst build env template
+description: Travis CI Amethyst build env template!
 variables:
   docker_repository: travisci/ci-amethyst
   docker_tag: packer-{{ timestamp }}

--- a/ci-sugilite.yml
+++ b/ci-sugilite.yml
@@ -1,5 +1,5 @@
 ---
-description: Travis CI sugilite build env template
+description: Travis CI sugilite build env template!
 variables:
   gce_account_file: "{{ env `GCE_ACCOUNT_FILE` }}"
   gce_project_id: "{{ env `GCE_PROJECT_ID` }}"


### PR DESCRIPTION
This change should further propagate the fix for https://github.com/travis-ci/travis-cookbooks/issues/878 to amethyst and sugilite.
Garnett was already successfully built after: https://github.com/travis-ci/packer-templates/pull/474