### PR TITLE
Remove (build) kernel version from system info command templates

### DIFF
--- a/packer-assets/amethyst-system-info-commands.yml
+++ b/packer-assets/amethyst-system-info-commands.yml
@@ -7,15 +7,11 @@ commands:
     name: Build image provisioning date and time
   - command: lsb_release -a
     name: Operating System Details
-  - command: uname -r
-    name: Linux Version
   osx:
   - command: date
     name: Build image provisioning date and time
   - command: sw_vers
     name: Operating System Details
-  - command: uname -r
-    name: Darwin Version
   common:
   - command: git --version
     name: git version

--- a/packer-assets/connie-system-info-commands.yml
+++ b/packer-assets/connie-system-info-commands.yml
@@ -7,15 +7,11 @@ commands:
     name: Build image provisioning date and time
   - command: lsb_release -a
     name: Operating System Details
-  - command: uname -r
-    name: Linux Version
   osx:
   - command: date
     name: Build image provisioning date and time
   - command: sw_vers
     name: Operating System Details
-  - command: uname -r
-    name: Darwin Version
   common:
   - command: git --version
     name: git version

--- a/packer-assets/cookiecat-system-info-commands.yml
+++ b/packer-assets/cookiecat-system-info-commands.yml
@@ -7,15 +7,11 @@ commands:
     name: Build image provisioning date and time
   - command: lsb_release -a
     name: Operating System Details
-  - command: uname -r
-    name: Linux Version
   osx:
   - command: date
     name: Build image provisioning date and time
   - command: sw_vers
     name: Operating System Details
-  - command: uname -r
-    name: Darwin Version
   common:
   - command: git --version
     name: git version

--- a/packer-assets/garnet-system-info-commands.yml
+++ b/packer-assets/garnet-system-info-commands.yml
@@ -7,15 +7,11 @@ commands:
     name: Build image provisioning date and time
   - command: lsb_release -a
     name: Operating System Details
-  - command: uname -r
-    name: Linux Version
   osx:
   - command: date
     name: Build image provisioning date and time
   - command: sw_vers
     name: Operating System Details
-  - command: uname -r
-    name: Darwin Version
   common:
   - command: git --version
     name: git version

--- a/packer-assets/stevonnie-system-info-commands.yml
+++ b/packer-assets/stevonnie-system-info-commands.yml
@@ -7,15 +7,11 @@ commands:
     name: Build image provisioning date and time
   - command: lsb_release -a
     name: Operating System Details
-  - command: uname -r
-    name: Linux Version
   osx:
   - command: date
     name: Build image provisioning date and time
   - command: sw_vers
     name: Operating System Details
-  - command: uname -r
-    name: Darwin Version
   common:
   - command: git --version
     name: git version

--- a/packer-assets/sugilite-system-info-commands.yml
+++ b/packer-assets/sugilite-system-info-commands.yml
@@ -7,15 +7,11 @@ commands:
     name: Build image provisioning date and time
   - command: lsb_release -a
     name: Operating System Details
-  - command: uname -r
-    name: Linux Version
   osx:
   - command: date
     name: Build image provisioning date and time
   - command: sw_vers
     name: Operating System Details
-  - command: uname -r
-    name: Darwin Version
   common:
   - command: git --version
     name: git version

--- a/packer-assets/system-info.d/basic.yml
+++ b/packer-assets/system-info.d/basic.yml
@@ -2,11 +2,9 @@ commands:
   linux:
     - { command: date -u, name: Build image provisioning date and time }
     - { command: lsb_release -a, name: Operating System Details }
-    - { command: uname -r, name: Linux Version }
   osx:
     - { command: date, name: Build image provisioning date and time }
     - { command: sw_vers, name: Operating System Details }
-    - { command: uname -r, name: Darwin Version }
   common:
     - { command: git --version, name: git version }
     - { command: bash --version, pipe: head -1, name: bash version }


### PR DESCRIPTION
Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?
Currently, the system info fold shows the kernel version that the image was built with, which is not always the kernel version that is running the current build.

2. What approach did you choose and why?
We added the runtime kernel information to the output [here](https://github.com/travis-ci/travis-build/pull/1138), and are now removing the old build kernel information. 

3. How can you test this?
Adding the new information has been tested and verified to work, this is just removing the inaccurate info.
