### PR TITLE
Update to latest PHP patch releases

### DIFF
--- a/ci-amethyst.yml
+++ b/ci-amethyst.yml
@@ -1,5 +1,5 @@
 ---
-description: Travis CI Amethyst build env template!
+description: Travis CI Amethyst build env template
 variables:
   docker_repository: travisci/ci-amethyst
   docker_tag: packer-{{ timestamp }}

--- a/ci-connie.yml
+++ b/ci-connie.yml
@@ -1,5 +1,5 @@
 ---
-description: Travis CI connie build env template!
+description: Travis CI connie build env template
 variables:
   docker_repository: travisci/ci-connie
   docker_tag: packer-{{ timestamp }}

--- a/ci-garnet.yml
+++ b/ci-garnet.yml
@@ -1,5 +1,5 @@
 ---
-description: Travis CI garnet build env template!
+description: Travis CI garnet build env template
 variables:
   docker_repository: travisci/ci-garnet
   docker_tag: packer-{{ timestamp }}

--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -1,5 +1,5 @@
 ---
-description: Travis CI stevonnie build env template!
+description: Travis CI stevonnie build env template
 variables:
   docker_repository: travisci/ci-stevonnie
   docker_tag: packer-{{ timestamp }}

--- a/ci-sugilite.yml
+++ b/ci-sugilite.yml
@@ -1,5 +1,5 @@
 ---
-description: Travis CI sugilite build env template!
+description: Travis CI sugilite build env template
 variables:
   gce_account_file: "{{ env `GCE_ACCOUNT_FILE` }}"
   gce_project_id: "{{ env `GCE_PROJECT_ID` }}"

--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -14,14 +14,14 @@ override['travis_system_info']['commands_file'] = \
   '/var/tmp/garnet-system-info-commands.yml'
 
 php_versions = %w[
-  5.6.24
-  7.0.7
+  5.6.31
+  7.0.22
 ]
 override['travis_build_environment']['php_versions'] = php_versions
-override['travis_build_environment']['php_default_version'] = '5.6.24'
+override['travis_build_environment']['php_default_version'] = '5.6.31'
 override['travis_build_environment']['php_aliases'] = {
-  '5.6' => '5.6.24',
-  '7.0' => '7.0.7'
+  '5.6' => '5.6.31',
+  '7.0' => '7.0.22'
 }
 
 override['travis_perlbrew']['perls'] = []

--- a/cookbooks/travis_ci_sugilite/attributes/default.rb
+++ b/cookbooks/travis_ci_sugilite/attributes/default.rb
@@ -15,17 +15,17 @@ override['travis_system_info']['commands_file'] = \
 
 php_versions = %w[
   5.4.45
-  5.5.37
-  5.6.24
-  7.0.7
+  5.5.38
+  5.6.31
+  7.0.22
 ]
 override['travis_build_environment']['php_versions'] = php_versions
-override['travis_build_environment']['php_default_version'] = '5.6.24'
+override['travis_build_environment']['php_default_version'] = '5.6.31'
 override['travis_build_environment']['php_aliases'] = {
   '5.4' => '5.4.45',
-  '5.5' => '5.5.37',
-  '5.6' => '5.6.24',
-  '7.0' => '7.0.7'
+  '5.5' => '5.5.38',
+  '5.6' => '5.6.31',
+  '7.0' => '7.0.22'
 }
 
 override['travis_perlbrew']['perls'] = [


### PR DESCRIPTION
Version numbers taken from:
https://secure.php.net/downloads.php

It may also be worth adding PHP 7.1 at some point (it's actually listed in the cookbook defaults, but overridden by here). However to save space I imagine it would make sense to drop the EOL PHP 5.4 at the same time - a decision I'll leave to another day.