### PR TITLE
Update Python versions

### DIFF
--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -60,7 +60,7 @@ override['travis_build_environment']['nodejs_default'] = node_versions.max
 
 pythons = %w[
   2.7.13
-  3.5.3
+  3.6.2
 ]
 
 # Reorder pythons so that default python2 and python3 come first

--- a/cookbooks/travis_ci_sugilite/attributes/default.rb
+++ b/cookbooks/travis_ci_sugilite/attributes/default.rb
@@ -117,10 +117,10 @@ override['travis_build_environment']['nodejs_default'] = node_versions.max
 pythons = %w[
   2.7.13
   3.3.6
-  3.4.6
-  3.5.3
-  3.6.1
-  pypy2-5.6.0
+  3.4.7
+  3.5.4
+  3.6.2
+  pypy2.7-5.8.0
 ]
 
 # Reorder pythons so that default python2 and python3 come first


### PR DESCRIPTION
I bumped all Python versions to the latest patch release.

In addition, I changed garnet's Python 3 version from 3.5.x to 3.6.x, since if it is only going to install one of each of Python 2 and 3, then it makes sense for it to be the latest of each. I'm happy to revert this part if preferred.

For latest version numbers see:
https://www.python.org/downloads/