### PR TITLE
Update nodejs versions

### DIFF
--- a/cookbooks/travis_ci_amethyst/attributes/default.rb
+++ b/cookbooks/travis_ci_amethyst/attributes/default.rb
@@ -62,7 +62,7 @@ override['travis_java']['default_version'] = 'oraclejdk8'
 override['travis_java']['alternate_versions'] = []
 
 node_versions = %w[
-  6.9.4
+  6.11.3
 ]
 
 override['travis_build_environment']['nodejs_versions'] = node_versions

--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -51,8 +51,8 @@ override['leiningen']['home'] = '/home/travis'
 override['leiningen']['user'] = 'travis'
 
 node_versions = %w[
-  6.9.4
-  7.4.0
+  6.11.3
+  8.4.0
 ]
 
 override['travis_build_environment']['nodejs_versions'] = node_versions

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -62,7 +62,7 @@ override['travis_java']['default_version'] = 'oraclejdk8'
 override['travis_java']['alternate_versions'] = []
 
 node_versions = %w[
-  6.9.4
+  6.11.3
 ]
 
 override['travis_build_environment']['nodejs_versions'] = node_versions

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -51,8 +51,8 @@ override['leiningen']['home'] = '/home/travis'
 override['leiningen']['user'] = 'travis'
 
 node_versions = %w[
-  6.9.4
-  7.4.0
+  6.11.3
+  8.4.0
 ]
 
 override['travis_build_environment']['nodejs_versions'] = node_versions


### PR DESCRIPTION
Since amethyst only has one nodejs version installed, I've left it at the most recent LTS release (the v6 series). For garnet I've used latest LTS (v6) and latest stable (v8).

~For sugilite, I've added the latest stable (v8), however to keep the image size comparable, I've also dropped the long ago EOLed v0.12 series. We could probably also drop the v4 and v5 series, but it would be good to know some usage stats first to avoid making lots of jobs have to download at runtime.~
(I've dropped the sugilite part of this PR given it's about to be removed in #498)

Version numbers taken from:
https://nodejs.org/en/download/releases/