### PR TITLE
Import our public keys to worker instances in a non-rate-limited way

### DIFF
--- a/cookbooks/travis_internal_base/files/default/00-create-users
+++ b/cookbooks/travis_internal_base/files/default/00-create-users
@@ -61,7 +61,8 @@ __add_github_keys() {
   mkdir -p "${ssh_dir}"
   chmod 0700 "${ssh_dir}"
 
-  ssh-import-id -o "${ssh_dir}/authorized_keys" "gh:${github_username}"
+  URL=https://github.com/%s.keys \
+    ssh-import-id -o "${ssh_dir}/authorized_keys" "${github_username}"
   chown -R "${username}:${username}" "${ssh_dir}"
 }
 


### PR DESCRIPTION
This PR makes it so `ssh-import-id` uses https://github.com/USER.keys URL instead of GitHub API, which is subject to rate-limiting, during the cloud init process.

Please make sure you cover the following points:

## What is the problem that this PR is trying to fix?

When a worker instance is booted, we request a dozen or so user keys via `ssh-import-id` which uses the GitHub API, which is rate-limited.

When we hit the rate limit, any remaining public keys are not imported and the worker instance is thus not accessible via SSH to those users whose keys have not been added.

## What approach did you choose and why?

If this PR is accepted, the cloud init script will still use `ssh-import-id` but will access the public key via the https://github.com/USER.keys URL instead of via the GitHub API.

## How can you test this?

I'm not sure, but would love to know a way.

The error in the worker instance boot logs is:
```
ERROR: string indices must be integers
2017-09-03 22:07:12,136 ERROR Error executing protocol helper [/usr/bin/ssh-import-id-gh]
```
(Note: on my machine, `/usr/bin/ssh-import-id-gh` is a basic wrapper around `ssh-import-id`.)

I tried to reproduce this error locally, but haven't been able to. When I hit the rate limit, the error I get locally is:
```
$ __add_github_keys soulshake soulshake
GitHub REST API rate-limited this IP address. See https://developer.github.com/v3/#rate-limiting
```

I guess this could be due to differing versions of `ssh-import-id`, but it looks like this behavior [was fixed in 2015](https://bugs.launchpad.net/ssh-import-id/+bug/1397332).

**UPDATE**: I found an instance (`i-0ec3d960fdbb0e3a8`) I could actually SSH into, and can confirm that we are using an extremely dated version of `ssh-import-id` on workers (`Copyright (c) 2013` according to the file):

```
i-0ec3d96-production-2-worker-org-ec2% ls -la /usr/bin/ssh-import-id*
-rwxr-xr-x 1 root root 7771 Feb 27  2014 /usr/bin/ssh-import-id
-rwxr-xr-x 1 root root 2118 Feb 27  2014 /usr/bin/ssh-import-id-gh
-rwxr-xr-x 1 root root 2509 Feb 27  2014 /usr/bin/ssh-import-id-lp
```

```
i-0ec3d96-production-2-worker-org-ec2% sudo apt install ssh-import-id
Reading package lists... Done
Building dependency tree       
Reading state information... Done
ssh-import-id is already the newest version (3.21-0ubuntu1).
```

While the ratelimiting would be handled more gracefully if we upgraded `ssh-import-id`, it would still fail. So I think this PR is still the simplest solution.

---

This addresses https://github.com/travis-pro/team-blue/issues/741