### PR TITLE
Fix test failures after travis-cookbooks shfmt 2 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ env:
   - PACKER_CHEF_PREFIX="${TRAVIS_BUILD_DIR}/tmp"
   - PATH="/opt/chefdk/bin:/opt/chefdk/embedded/bin:/opt/chef/bin:${HOME}/bin:${PATH}"
   - REQUEST_INTERVAL=5
-  - SHELLCHECK_URL="https://s3.amazonaws.com/travis-blue-public/binaries/ubuntu/14.04/x86_64/shellcheck-0.4.5.tar.bz2"
-  - SHFMT_URL="https://github.com/mvdan/sh/releases/download/v0.6.0/shfmt_v0.6.0_linux_amd64"
   - SKIP_CHEFDK_REMOVAL='1'
   - SPEC_ARGS='--tag ~dev'
   - SPEC_RUNNER='bash -lc'
@@ -31,15 +29,6 @@ install:
   fi
 - rvm use 2.4.1 --install --binary --fuzzy
 - bundle install --jobs=3 --retry=2 --path=vendor/bundle
-- if ! shellcheck --version &>/dev/null; then
-    curl -sSL "${SHELLCHECK_URL}"
-    | tar --exclude 'SHA256SUMS' --strip-components=1 -C "${HOME}/bin" -xjf -;
-  fi
-- shellcheck --version
-- if ! command -v shfmt; then
-    curl -sSL "${SHFMT_URL}" -o "${HOME}/bin/shfmt";
-    chmod +x "${HOME}/bin/shfmt";
-  fi
 - ./bin/packer-build-install
 - ln -sv "${TRAVIS_BUILD_DIR}" "${TRAVIS_BUILD_DIR}/tmp/packer-chef-local"
 

--- a/bin/check-job-board-tags
+++ b/bin/check-job-board-tags
@@ -15,13 +15,13 @@ main() {
   set -o pipefail
 
   case "$1" in
-    -h | --help | help)
-      __usage
-      exit 0
-      ;;
-    -l | --list-only)
-      CHECK_JOB_BOARD_TAGS_LIST_ONLY=1
-      ;;
+  -h | --help | help)
+    __usage
+    exit 0
+    ;;
+  -l | --list-only)
+    CHECK_JOB_BOARD_TAGS_LIST_ONLY=1
+    ;;
   esac
 
   COMBOS=(
@@ -51,8 +51,8 @@ ${rec}
 "
   done
 
-  echo "${BATCH_INPUT}" | ./bin/assert-job-board-tags -i \
-    | grep --color -E '^✘:.*|$'
+  echo "${BATCH_INPUT}" | ./bin/assert-job-board-tags -i |
+    grep --color -E '^✘:.*|$'
 }
 
 __usage() {

--- a/bin/gce-image-update
+++ b/bin/gce-image-update
@@ -32,8 +32,8 @@ __fetch_curimg() {
 __fetch_newimg() {
   local rel="${1}"
 
-  gcloud compute images list --format=json --regexp="ubuntu-${rel}-.*" \
-    | jq -r '.[] | .name' | head -1
+  gcloud compute images list --format=json --regexp="ubuntu-${rel}-.*" |
+    jq -r '.[] | .name' | head -1
 }
 
 __sed() {

--- a/bin/list-stacks
+++ b/bin/list-stacks
@@ -15,8 +15,8 @@ main() {
   cd "${top}"
 
   for f in ci-*.yml; do
-    grep -lE "travis_cookbooks_edge_branch:.*${edge_branch}" "${f}" \
-      | "${sed}" "s/ci-//;s/\\.yml//;s/\$/-${dist}/"
+    grep -lE "travis_cookbooks_edge_branch:.*${edge_branch}" "${f}" |
+      "${sed}" "s/ci-//;s/\\.yml//;s/\$/-${dist}/"
   done
 }
 

--- a/bin/nodejs-latest-versions
+++ b/bin/nodejs-latest-versions
@@ -11,14 +11,14 @@ main() {
   trap 'rm -f '"${index_json}" EXIT QUIT INT TERM
 
   echo -n 'lts: '
-  jq -r '.[]|select(.lts)|.version' <"${index_json}" \
-    | sort --reverse \
-    | head -1
+  jq -r '.[]|select(.lts)|.version' <"${index_json}" |
+    sort --reverse |
+    head -1
 
   echo -n 'current: '
-  jq -r '.[]|select(.lts==false)|.version' <"${index_json}" \
-    | sort --reverse \
-    | head -1
+  jq -r '.[]|select(.lts==false)|.version' <"${index_json}" |
+    sort --reverse |
+    head -1
 }
 
 main "$@"

--- a/bin/packer-build-install
+++ b/bin/packer-build-install
@@ -7,9 +7,9 @@ cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
 mkdir -p tmp/
 
 if [[ -n "${GCE_ACCOUNT_FILE_B64_BZ2}" ]]; then
-  echo "${GCE_ACCOUNT_FILE_B64_BZ2}" \
-    | base64 -d \
-    | bunzip2 >tmp/gce.json
+  echo "${GCE_ACCOUNT_FILE_B64_BZ2}" |
+    base64 -d |
+    bunzip2 >tmp/gce.json
 fi
 
 if [[ "$(packer version 2>/dev/null)" != "Packer v1.0.0" ]]; then

--- a/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
+++ b/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
@@ -32,8 +32,8 @@ main() {
   )"
   hosts_line="${instance_ipv4} ${instance_hostname} ${instance_hostname%%.*}"
 
-  echo "${instance_hostname}" \
-    | tee "${ETCDIR}/hostname" >"${RUNDIR}/instance-hostname"
+  echo "${instance_hostname}" |
+    tee "${ETCDIR}/hostname" >"${RUNDIR}/instance-hostname"
   hostname -F "${ETCDIR}/hostname"
 
   if ! grep -q "^${hosts_line}" "${ETCDIR}/hosts"; then

--- a/packer-scripts/create-bin-lib-checksums
+++ b/packer-scripts/create-bin-lib-checksums
@@ -17,9 +17,9 @@ __checksum() {
   find "${@}" \
     -executable -type f -print0 \
     -or -name '*.so' -print0 \
-    -or -name '*.a' -print0 2>/dev/null \
-    | xargs -0 sha256sum 2>/dev/null \
-    | sort -k2
+    -or -name '*.a' -print0 2>/dev/null |
+    xargs -0 sha256sum 2>/dev/null |
+    sort -k2
 }
 
 main "$@"

--- a/packer-scripts/create-image-metadata-tarball
+++ b/packer-scripts/create-image-metadata-tarball
@@ -21,8 +21,8 @@ main() {
 
   find "${RSPEC_JSON_DIR}" \
     -maxdepth 1 \
-    -name '.*_rspec.json' \
-    | while read -r rspec_json; do
+    -name '.*_rspec.json' |
+    while read -r rspec_json; do
       cp -v "${rspec_json}" "${dest}/${rspec_json##*/.}"
     done
 

--- a/packer-scripts/dump-dpkg-manifest
+++ b/packer-scripts/dump-dpkg-manifest
@@ -7,12 +7,12 @@ main() {
   package_field="$(__get_package_field)"
   (
     echo '{'
-    dpkg --get-selections \
-      | awk '/\sinstall$/ { print $1 }' \
-      | xargs dpkg-query -W -f="\"\${${package_field}}\": \"\${Version}\",\\n"
+    dpkg --get-selections |
+      awk '/\sinstall$/ { print $1 }' |
+      xargs dpkg-query -W -f="\"\${${package_field}}\": \"\${Version}\",\\n"
     echo "\"__timestamp\": \"$(date +%Y%m%dT%H%M%S)\"}"
-  ) | python -m json.tool \
-    | tee "${DPKG_MANIFEST_JSON}"
+  ) | python -m json.tool |
+    tee "${DPKG_MANIFEST_JSON}"
 }
 
 __get_package_field() {

--- a/packer-scripts/minimize
+++ b/packer-scripts/minimize
@@ -17,8 +17,8 @@ main() {
       readonly SWAP_PART
       SWAP_PART="$(readlink -f "/dev/disk/by-uuid/${SWAP_UUID}")"
       /sbin/swapoff "${SWAP_PART}"
-      dd if=/dev/zero of="${SWAP_PART}" bs=1M \
-        || echo "dd exit $? suppressed"
+      dd if=/dev/zero of="${SWAP_PART}" bs=1M ||
+        echo "dd exit $? suppressed"
       /sbin/mkswap -U "${SWAP_UUID}" "${SWAP_PART}"
     fi
   fi
@@ -38,10 +38,10 @@ main() {
   rm -f /EMPTY
   sync
 
-  vmware-toolbox-cmd disk shrink / \
-    || echo "vmware-toolbox-cmd exit $? suppressed"
-  vmware-toolbox-cmd disk shrink /boot \
-    || echo "vmware-toolbox-cmd exit $? suppressed"
+  vmware-toolbox-cmd disk shrink / ||
+    echo "vmware-toolbox-cmd exit $? suppressed"
+  vmware-toolbox-cmd disk shrink /boot ||
+    echo "vmware-toolbox-cmd exit $? suppressed"
 }
 
 main "${@}"

--- a/packer-scripts/pre-chef-bootstrap
+++ b/packer-scripts/pre-chef-bootstrap
@@ -65,8 +65,8 @@ __upgrade_apt() {
   dist_name="$(lsb_release -sc)"
 
   if ! [[ "${arch_type}" =~ ppc64le ]]; then
-    curl -sSL https://packagecloud.io/install/repositories/computology/apt-backport/script.deb.sh \
-      | bash
+    curl -sSL https://packagecloud.io/install/repositories/computology/apt-backport/script.deb.sh |
+      bash
     apt-get update -yqq
   fi
   if ! [[ "${dist_name}" =~ xenial ]]; then

--- a/packer-scripts/purge
+++ b/packer-scripts/purge
@@ -36,8 +36,8 @@ __purge_from_manifest() {
 }
 
 __purge_packages() {
-  dpkg --list | awk '{ print $2 }' | grep -- "$1" \
-    | grep -v -- "${2:-^$}" | xargs apt-get -y purge
+  dpkg --list | awk '{ print $2 }' | grep -- "$1" |
+    grep -v -- "${2:-^$}" | xargs apt-get -y purge
 }
 
 __run_retry() {


### PR DESCRIPTION
**1. What is the problem that this PR is trying to fix?**

Test runs based on packer-templates master [no longer pass](https://travis-ci.org/travis-ci/packer-templates/builds/274230149#L864) after shfmt was updated to v2 in travis-ci/travis-cookbooks#901. This is because:

(a) The version of shfmt used by the tests in this repository is effectively unpinned (since there is no version check in the install step in `.travis.yml`)
(b) shfmt 2 made some backwards incompatible changes ([release notes](https://github.com/mvdan/sh/releases/tag/v2.0.0))

**2. What approach did you choose and why?**

* I ran shfmt 2 locally to reformat the shell scripts. (If the old style is preferred, shfmt 2 comes with new command line options to revert back to the old style for both the pipe operator change, and the switch statement change - see [release notes](https://github.com/mvdan/sh/releases/tag/v2.0.0)).
* I also removed the shfmt and shellcheck install steps from `.travis.yml` since:
  - both tools are already installed in the `garnet` image used for this CI run anyway.
  - no version number is enforced, so the pre-installed version causes the install to be skipped, and thus adds confusion, since the version appears to be pinned (via `{SHFMT,SHELLCHECK}_URL`) when really it isn't.
  -  whilst this approach will still result in breakage if a new base image version includes backwards incompatible changes, it saves having to increment the version in yet another location, plus provides additional testing of the images themselves.

**3. How can you test this?**

The CI run on this repo should be sufficient.

**4. What feedback would you like?**

a) Whether to use the shfmt options to return to the old shfmt v1 pipe and/or switch style.
b) Whether to not remove the shfmt/shellcheck install steps from `.travis.yml` and instead make them enforce exact versions.