### PR TITLE
Update garnet/sardonyx to latest Python 3 release

### DIFF
--- a/cookbooks/lib/languages/python_spec.rb
+++ b/cookbooks/lib/languages/python_spec.rb
@@ -40,15 +40,15 @@ describe 'python environment' do
 
   {
     'python2.7' => '2.7.13',
-    'python3.5' => '3.5.3'
+    'python3.6' => '3.6.2'
   }.each do |python_alias, python_version|
-    describe pycommand('python -m this', version: python_alias) do
+    describe pycommand('python -m this', version: python_alias), dev: true do
       its(:stderr) { should be_empty }
       its(:stdout) { should include('Now is better than never') }
       its(:exit_status) { should eq(0) }
     end
 
-    describe pycommand('python --version', version: python_alias) do
+    describe pycommand('python --version', version: python_alias), dev: true do
       stream = python_alias < 'python3' ? :stderr : :stdout
       its(stream) { should include("Python #{python_version}") }
     end

--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -60,7 +60,7 @@ override['travis_build_environment']['nodejs_default'] = node_versions.max
 
 pythons = %w[
   2.7.13
-  3.5.3
+  3.6.2
 ]
 
 # Reorder pythons so that default python2 and python3 come first

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -60,7 +60,7 @@ override['travis_build_environment']['nodejs_default'] = node_versions.max
 
 pythons = %w[
   2.7.13
-  3.5.3
+  3.6.2
 ]
 
 # Reorder pythons so that default python2 and python3 come first


### PR DESCRIPTION
**1. What is the problem that this PR is trying to fix?**
garnet/sardonyx have been updated from Python 3.5.x to 3.6.x, since if they're only going to install one of each of Python 2 and 3, then it makes sense for it to be the latest of each.

For latest version numbers see:
https://www.python.org/downloads/

~**2. What approach did you choose and why?**~

**3. How can you test this?**
- [garnet](https://travis-ci.org/travis-infrastructure/packer-build/builds/274369263):  :smiley_cat:
- [sardonyx](https://travis-ci.org/travis-infrastructure/packer-build/builds/274369266):  :crying_cat_face: (but this is due to #501 rather than this PR)

**4. What feedback would you like?**
What are the Python version usage stats? Now that we no longer have sugilite (which used to install 5 or so different Python versions), should we adjust the versions installed in garnet/sardonyx differently or install more versions? (Though it would be nice to not bloat garnet, so perhaps not worth it)