### PR TITLE
Use be_writable instead of manual file creation in basic_spec.rb

### DIFF
--- a/cookbooks/lib/features/basic_spec.rb
+++ b/cookbooks/lib/features/basic_spec.rb
@@ -603,12 +603,7 @@ end
 
 describe file('/home/travis/bin') do
   it { should be_directory }
-  it 'is writable' do
-    File.open('/home/travis/bin/.travis-write-test', 'w') do |f|
-      f.puts Time.now.utc.to_s
-    end
-    expect(File.read('/home/travis/bin/.travis-write-test')).to_not be_empty
-  end
+  it { should be_writable }
 end
 
 def test_txt
@@ -781,12 +776,7 @@ end
 
 describe file('/opt') do
   it { should be_directory }
-  it 'is writable' do
-    File.open('/opt/.travis-write-test', 'w') do |f|
-      f.puts Time.now.utc.to_s
-    end
-    expect(File.read('/opt/.travis-write-test')).to_not be_empty
-  end
+  it { should be_writable }
 end
 
 describe file('/etc/hosts'), docker: false do


### PR DESCRIPTION
This reduces boilerplate as well as stopping the files being left behind, thereby avoiding cache invalidation.

See:
http://serverspec.org/resource_types.html#be_writable
https://github.com/mizzy/serverspec/blob/v2.39.1/lib/serverspec/type/file.rb#L75-L81

Fixes #513.