### PR TITLE
Ensure uuid-dev is installed on all Trusty and Xenial stacks

### DIFF
--- a/packer-assets/ubuntu-trusty-ci-amethyst-docker-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-amethyst-docker-packages.txt
@@ -4,6 +4,7 @@ libqt4-opengl-dev
 libqtwebkit-dev
 libqtwebkit4
 scons
+uuid-dev
 x11-utils
 x11-xserver-utils
 xserver-xorg-core

--- a/packer-assets/ubuntu-trusty-ci-amethyst-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-amethyst-packages.txt
@@ -480,6 +480,7 @@ update-notifier-common
 upstart
 usbutils
 util-linux
+uuid-dev
 uuid-runtime
 vim
 vim-common

--- a/packer-assets/ubuntu-trusty-ci-connie-docker-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-connie-docker-packages.txt
@@ -1,2 +1,3 @@
 libmysqlclient-dev
 mysql-client
+uuid-dev

--- a/packer-assets/ubuntu-trusty-ci-connie-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-connie-packages.txt
@@ -476,6 +476,7 @@ update-notifier-common
 upstart
 usbutils
 util-linux
+uuid-dev
 uuid-runtime
 vim
 vim-common

--- a/packer-assets/ubuntu-trusty-ci-cookiecat-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-cookiecat-packages.txt
@@ -480,6 +480,7 @@ update-notifier-common
 upstart
 usbutils
 util-linux
+uuid-dev
 uuid-runtime
 vim
 vim-common

--- a/packer-assets/ubuntu-trusty-ci-garnet-docker-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-garnet-docker-packages.txt
@@ -8,6 +8,7 @@ libqt4-opengl-dev
 libqtwebkit-dev
 libqtwebkit4
 scons
+uuid-dev
 x11-utils
 x11-xserver-utils
 xserver-xorg-core

--- a/packer-assets/ubuntu-trusty-ci-garnet-packages.txt
+++ b/packer-assets/ubuntu-trusty-ci-garnet-packages.txt
@@ -484,6 +484,7 @@ update-notifier-common
 upstart
 usbutils
 util-linux
+uuid-dev
 uuid-runtime
 vim
 vim-common

--- a/packer-assets/ubuntu-xenial-ci-opal-docker-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-opal-docker-packages.txt
@@ -1,0 +1,1 @@
+uuid-dev

--- a/packer-assets/ubuntu-xenial-ci-opal-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-opal-packages.txt
@@ -1,0 +1,1 @@
+uuid-dev

--- a/packer-assets/ubuntu-xenial-ci-sardonyx-docker-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-sardonyx-docker-packages.txt
@@ -1,0 +1,1 @@
+uuid-dev

--- a/packer-assets/ubuntu-xenial-ci-sardonyx-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-sardonyx-packages.txt
@@ -1,0 +1,1 @@
+uuid-dev

--- a/packer-assets/ubuntu-xenial-ci-stevonnie-docker-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-stevonnie-docker-packages.txt
@@ -4,3 +4,4 @@ hashdeep
 libmysqlclient-dev
 mysql-client
 postgresql-client
+uuid-dev

--- a/packer-assets/ubuntu-xenial-ci-stevonnie-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-stevonnie-packages.txt
@@ -469,6 +469,7 @@ update-notifier-common
 upstart
 usbutils
 util-linux
+uuid-dev
 uuid-runtime
 vim
 vim-common


### PR DESCRIPTION
We received word via support that some libraries were failing to install due to the uuid headers not being present.  I'm assuming the `uuid-dev` package had previously been installed via dependency, so here I'm making it explicit on all trusty and xenial stacks :+1: