### PR TITLE
 Changes to make run-serverspecs run on power

### DIFF
--- a/cookbooks/lib/features/basic_spec.rb
+++ b/cookbooks/lib/features/basic_spec.rb
@@ -436,16 +436,9 @@ if os[:arch] !~ /ppc64/
   end
 end
 
-if os[:release] == '16.04'
-  describe command('psql --version') do
-    its(:stdout) { should match(/^psql.+10\.[0-9]/) }
-    its(:exit_status) { should eq 0 }
-  end
-else
-  describe command('psql --version') do
-    its(:stdout) { should match(/^psql.+9\.[2-6]+\.[0-9]+/) }
-    its(:exit_status) { should eq 0 }
-  end
+describe command('psql --version') do
+  its(:stdout) { should match(/^psql.+9\.[2-6]+\.[0-9]+/) }
+  its(:exit_status) { should eq 0 }
 end
 
 describe 'ragel installation' do

--- a/cookbooks/lib/features/basic_spec.rb
+++ b/cookbooks/lib/features/basic_spec.rb
@@ -38,8 +38,10 @@ describe command('shellcheck --version') do
   its(:stdout) { should match(/^version: \d+\.\d+\.\d+/) }
 end
 
-describe command('shfmt -version') do
-  its(:stdout) { should match(/^v\d+\.\d+\.\d+/) }
+if os[:arch] !~ /ppc64/
+  describe command('shfmt -version') do
+    its(:stdout) { should match(/^v\d+\.\d+\.\d+/) }
+  end
 end
 
 def bzr_project
@@ -221,8 +223,14 @@ describe 'gimme installation' do
     its(:exit_status) { should eq 0 }
   end
 
-  describe command(%(eval "$(HOME=#{Support.tmpdir} gimme 1.6.3)" 2>&1)) do
-    its(:stdout) { should match 'go version go1.6.3' }
+  if os[:arch] !~ /ppc64/
+    describe command(%(eval "$(HOME=#{Support.tmpdir} gimme 1.6.3)" 2>&1)) do
+      its(:stdout) { should match 'go version go1.6.3' }
+    end
+  elsif os[:arch] =~ /ppc64/
+    describe command(%(eval "$(HOME=#{Support.tmpdir} gimme 1.6.4)" 2>&1)) do
+      its(:stdout) { should match 'go version go1.6.4 linux/ppc64le' }
+    end
   end
 end
 
@@ -279,8 +287,10 @@ describe 'git installation' do
   end
 end
 
-describe command('heroku version') do
-  its(:stdout) { should match(%r{^heroku-cli\/\d}) }
+if os[:arch] !~ /ppc64/
+  describe command('heroku version') do
+    its(:stdout) { should match(%r{^heroku-cli\/\d}) }
+  end
 end
 
 describe 'imagemagick installation' do
@@ -419,14 +429,23 @@ describe 'openssl installation' do
   end
 end
 
-describe command('packer version') do
-  its(:stdout) { should match(/^Packer v\d/) }
-  its(:exit_status) { should eq 0 }
+if os[:arch] !~ /ppc64/
+  describe command('packer version') do
+    its(:stdout) { should match(/^Packer v\d/) }
+    its(:exit_status) { should eq 0 }
+  end
 end
 
-describe command('psql --version') do
-  its(:stdout) { should match(/^psql.+9\.[2-6]+\.[0-9]+/) }
-  its(:exit_status) { should eq 0 }
+if os[:release] == '16.04'
+  describe command('psql --version') do
+    its(:stdout) { should match(/^psql.+10\.[0-9]/) }
+    its(:exit_status) { should eq 0 }
+  end
+else
+  describe command('psql --version') do
+    its(:stdout) { should match(/^psql.+9\.[2-6]+\.[0-9]+/) }
+    its(:exit_status) { should eq 0 }
+  end
 end
 
 describe 'ragel installation' do

--- a/packer-scripts/minimize
+++ b/packer-scripts/minimize
@@ -9,7 +9,7 @@ main() {
     exit 0
   fi
 
-  if [[ "${PACKER_BUILDER_TYPE}" != docker ]]; then
+  if [[ "${PACKER_BUILDER_TYPE}" != docker && "${PACKER_BUILDER_TYPE}" != openstack ]]; then
     readonly SWAP_UUID
     SWAP_UUID="$(/sbin/blkid -o value -l -s UUID -t TYPE=swap)"
 

--- a/packer-scripts/purge
+++ b/packer-scripts/purge
@@ -6,7 +6,11 @@ main() {
   set -o xtrace
   shopt -s nullglob
 
-  : "${PURGE_PACKAGE_DEFAULTS:=linux-headers,linux-source,chef,chefdk}"
+  if [[ "$(uname -m)" =~ ppc ]]; then
+    : "${PURGE_PACKAGE_DEFAULTS:=linux-headers,linux-source,chefdk}"
+  else
+    : "${PURGE_PACKAGE_DEFAULTS:=linux-headers,linux-source,chef,chefdk}"
+  fi
   export DEBIAN_FRONTEND='noninteractive'
 
   rm -rf /var/lib/apt/lists/* || echo "Suppressing exit $?"

--- a/packer-scripts/run-serverspecs
+++ b/packer-scripts/run-serverspecs
@@ -14,6 +14,10 @@ main() {
   : "${SPEC_RUNNER:=sudo -u travis HOME=/home/travis -- bash -lc}"
   : "${PACKER_BUILDER_TYPE:=docker}"
 
+  if [[ "$(uname -m)" =~ ppc64 ]]; then
+     exit 0
+  fi
+
   if [[ "${PACKER_BUILDER_TYPE}" == 'docker' ]]; then
     export SPEC_ARGS="${SPEC_ARGS} --tag ~docker:false"
   fi

--- a/packer-scripts/run-serverspecs
+++ b/packer-scripts/run-serverspecs
@@ -7,7 +7,7 @@ main() {
 
   export CHEF_PATH='/opt/chefdk/bin:/opt/chefdk/embedded/bin:/opt/chef/bin'
   if [[ "$(uname -m)" =~ ppc64 ]]; then
-    export CHEF_PATH=$CHEF_PATH:/opt/chef/embedded
+    export CHEF_PATH=$CHEF_PATH:/opt/chef/embedded/bin
   fi
   export PATH="$CHEF_PATH:$PATH"
   export DEBIAN_FRONTEND='noninteractive'

--- a/packer-scripts/run-serverspecs
+++ b/packer-scripts/run-serverspecs
@@ -6,6 +6,9 @@ main() {
   shopt -s nullglob
 
   export CHEF_PATH='/opt/chefdk/bin:/opt/chefdk/embedded/bin:/opt/chef/bin'
+  if [[ "$(uname -m)" =~ ppc64 ]]; then
+    export CHEF_PATH=$CHEF_PATH:/opt/chef/embedded
+  fi
   export PATH="$CHEF_PATH:$PATH"
   export DEBIAN_FRONTEND='noninteractive'
   export RUBYOPT='-W0'
@@ -14,15 +17,16 @@ main() {
   : "${SPEC_RUNNER:=sudo -u travis HOME=/home/travis -- bash -lc}"
   : "${PACKER_BUILDER_TYPE:=docker}"
 
-  if [[ "$(uname -m)" =~ ppc64 ]]; then
-    exit 0
-  fi
-
   if [[ "${PACKER_BUILDER_TYPE}" == 'docker' ]]; then
     export SPEC_ARGS="${SPEC_ARGS} --tag ~docker:false"
   fi
 
-  __install_chefdk "${PACKER_CHEF_PREFIX}"
+  if [[ "$(uname -m)" =~ ppc64 ]]; then
+    __install_serverspec
+  else
+    __install_chefdk "${PACKER_CHEF_PREFIX}"
+  fi
+
   # shellcheck disable=SC2119
   __create_sudo_bash
   __chown_travis_dirs "${PACKER_CHEF_PREFIX}"
@@ -31,11 +35,16 @@ main() {
     __run_suite "${suite}" "${PACKER_CHEF_PREFIX}" "${SPEC_RUNNER}"
   done
 
-  if [[ -z ${SKIP_CHEFDK_REMOVAL} ]]; then
+  if [[ "$(uname -m)" =~ ppc64 ]]; then
+    __remove_serverspec_chef
+  elif [[ -z ${SKIP_CHEFDK_REMOVAL} ]]; then
     __remove_chefdk
   fi
 }
 
+__install_serverspec() {
+  gem install -v 2.39.1 serverspec
+}
 __install_chefdk() {
   if [[ -f /opt/chefdk/embedded/bin/rspec ]]; then
     return
@@ -92,6 +101,11 @@ __remove_chefdk() {
   __run_retry 2 30 apt-get update -y
 }
 
+__remove_serverspec_chef() {
+  __run_retry 2 30 gem uninstall serverspec --version 2.39.1
+  __run_retry 2 30 apt-get purge -y chef
+  __run_retry 2 30 apt-get update -y
+}
 __run_suite() {
   local suite="${1}"
   local chef_prefix="${2}"

--- a/packer-scripts/run-serverspecs
+++ b/packer-scripts/run-serverspecs
@@ -15,7 +15,7 @@ main() {
   : "${PACKER_BUILDER_TYPE:=docker}"
 
   if [[ "$(uname -m)" =~ ppc64 ]]; then
-     exit 0
+    exit 0
   fi
 
   if [[ "${PACKER_BUILDER_TYPE}" == 'docker' ]]; then


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Utilizing chef and explicit gem installation instead of chefdk which is not available on power to run specs 

## What approach did you choose and why?
Tried running the packer template for ci-stevonie to create power image on Openstack setup

## How can you test this?

## What feedback would you like, if any?
Please review and let me know if we can temporarily skip this till an official port for chefdk is present