### PR TITLE
Add IBM Java 8 as a java alternative to garnet

### DIFF
--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -45,6 +45,7 @@ override['travis_java']['alternate_versions'] = %w[
   openjdk7
   openjdk8
   oraclejdk9
+  ibmjava8
 ]
 
 override['leiningen']['home'] = '/home/travis'


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Fixes https://github.com/travis-pro/team-blue/issues/703

## What approach did you choose and why?
Add the new recipe as an alternative.

## How can you test this?
Image built and tested as part of https://github.com/travis-ci/travis-cookbooks/pull/874