### PR TITLE
Remove pg_config test

### DIFF
--- a/cookbooks/lib/features/postgresql_spec.rb
+++ b/cookbooks/lib/features/postgresql_spec.rb
@@ -8,11 +8,6 @@ describe 'postgresql installation' do
     its(:exit_status) { should eq 0 }
   end
 
-  describe pgcommand('pg_config --bindir') do
-    its(:stdout) { should match(%r{/usr/lib/postgresql/9\.[2-6]/bin}) }
-    its(:exit_status) { should eq 0 }
-  end
-
   describe 'psql commands' do
     before do
       sh("#{pg_path} dropdb -U travis test_db || true")


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Postgres released version 10 a few days, which is causing this particular test to fail, blocking our image builds (e.g. https://travis-ci.org/travis-infrastructure/packer-build/builds/286096400)

## What approach did you choose and why?
As far as I understand it, `pg_conf` on Ubuntu is behaving a bit weird and makes --bindir basically point to the specific version of `libpq-dev` that's installed (regardless of any other postgres versions)

Since we're always installing the latest version, this test doesn't really make sense and will only break with any new version that gets released.

Alternatively, we could either pin both versions of postgresql-client and libpq-dev to make sure this doesn't happen anymore or update the test.

## How can you test this?
N/A

## What feedback would you like, if any?
Was anything I said above utter nonsense? :) 
Do you agree with this proposal or would prefer one of the alternatives?