### PR TITLE
Bump mainline kernel to 4.13.11

### DIFF
--- a/packer-scripts/install-ubuntu-mainline-kernel
+++ b/packer-scripts/install-ubuntu-mainline-kernel
@@ -9,7 +9,7 @@ main() {
   : "${APT_GET:=apt-get}"
   : "${CURL:=curl}"
   : "${DPKG:=dpkg}"
-  : "${KERNEL_VERSION:=4.11.6}"
+  : "${KERNEL_VERSION:=4.13.11}"
   : "${TMPDIR:=/var/tmp}"
 
   local kv="${KERNEL_VERSION}"

--- a/packer-scripts/pre-chef-bootstrap
+++ b/packer-scripts/pre-chef-bootstrap
@@ -47,6 +47,7 @@ __install_packages() {
     ca-certificates \
     cron \
     curl \
+    gawk \
     git \
     sudo \
     wget \


### PR DESCRIPTION
plus ensure gawk is installed so that the regexes work correctly.

## What is the problem that this PR is trying to fix?

The kernel used by the tfw image is from June 2017, which is in the past by more than a month.

## What approach did you choose and why?

Bump the kernel version to 4.13.11, which was released at the beginning of November.

## How can you test this?

- [x] tfw image builds
- [x] tfw image works in staging (AWS staging worker(s))