### PR TITLE
Try rolling back to kernel 4.9.60

### DIFF
--- a/packer-scripts/install-ubuntu-mainline-kernel
+++ b/packer-scripts/install-ubuntu-mainline-kernel
@@ -9,7 +9,7 @@ main() {
   : "${APT_GET:=apt-get}"
   : "${CURL:=curl}"
   : "${DPKG:=dpkg}"
-  : "${KERNEL_VERSION:=4.13.11}"
+  : "${KERNEL_VERSION:=4.9.60}"
   : "${TMPDIR:=/var/tmp}"
 
   local kv="${KERNEL_VERSION}"

--- a/packer-scripts/install-ubuntu-mainline-kernel
+++ b/packer-scripts/install-ubuntu-mainline-kernel
@@ -9,7 +9,7 @@ main() {
   : "${APT_GET:=apt-get}"
   : "${CURL:=curl}"
   : "${DPKG:=dpkg}"
-  : "${KERNEL_VERSION:=4.9.60}"
+  : "${KERNEL_VERSION:=4.9.6}"
   : "${TMPDIR:=/var/tmp}"
 
   local kv="${KERNEL_VERSION}"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

https://github.com/travis-ci/packer-templates/pull/537 didn't help with the stalling Docker issue, alas.

## What approach did you choose and why?

Roll back to most recent long-term stable kernel, `4.9.6`.