### PR TITLE
Remove ibmjava8 from our images

### DIFF
--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -45,7 +45,6 @@ override['travis_java']['alternate_versions'] = %w[
   openjdk7
   openjdk8
   oraclejdk9
-  ibmjava8
 ]
 
 override['leiningen']['home'] = '/home/travis'


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

IBM Java 8 is currently breaking any new image builds due to a ChecksumMismatch: https://travis-ci.org/travis-infrastructure/packer-build/jobs/298470058#L2180
Additionally, we've decided that the last updates for Trusty shouldn't introduce any major changes (we want the LTS image version to be as stable as possible), so we've decided it might be better to postpone supporting this for Xenial only.

## What approach did you choose and why?
Remove ibmjava8 from garnet alternate java versions.

## How can you test this?
Check that a new image builds successfully.
Check that Java 8 isn't included in the newly built image
