### PR TITLE
Remove failing rabbitmq check

### DIFF
--- a/.packer-build-pull-request-false-tmpl.yml
+++ b/.packer-build-pull-request-false-tmpl.yml
@@ -7,7 +7,6 @@ config:
   group: edge
   sudo: true
   before_install:
-  - export TRAVIS_COOKBOOKS_BRANCH="bv-build-image-fixes"
   - if [[ "${BUILDER}" = "docker" ]] ; then
       sudo apt-get update -yqq ;
       sudo apt-get purge -o Dpkg::Options::="--force-confnew" -yqq docker-ce ;

--- a/.packer-build-pull-request-false-tmpl.yml
+++ b/.packer-build-pull-request-false-tmpl.yml
@@ -7,6 +7,7 @@ config:
   group: edge
   sudo: true
   before_install:
+  - TRAVIS_COOKBOOKS_BRANCH="bv-build-image-fixes"
   - if [[ "${BUILDER}" = "docker" ]] ; then
       sudo apt-get update -yqq ;
       sudo apt-get purge -o Dpkg::Options::="--force-confnew" -yqq docker-ce ;

--- a/.packer-build-pull-request-false-tmpl.yml
+++ b/.packer-build-pull-request-false-tmpl.yml
@@ -7,7 +7,7 @@ config:
   group: edge
   sudo: true
   before_install:
-  - TRAVIS_COOKBOOKS_BRANCH="bv-build-image-fixes"
+  - export TRAVIS_COOKBOOKS_BRANCH="bv-build-image-fixes"
   - if [[ "${BUILDER}" = "docker" ]] ; then
       sudo apt-get update -yqq ;
       sudo apt-get purge -o Dpkg::Options::="--force-confnew" -yqq docker-ce ;

--- a/cookbooks/lib/features/rabbitmq_spec.rb
+++ b/cookbooks/lib/features/rabbitmq_spec.rb
@@ -22,10 +22,6 @@ describe 'rabbitmq installation' do
   end
 
   describe 'rabbitmq commands', sudo: true do
-    describe service('rabbitmq-server') do
-      it { should be_running }
-    end
-
     if os[:release] !~ /16/
       describe command('sudo service rabbitmq-server status') do
         its(:stdout) { should match 'running_applications' }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Image builds were failing due to this particular test.
Example build: https://travis-ci.org/travis-infrastructure/packer-build/jobs/299032357

## What approach did you choose and why?
I want to start by saying that removing tests because they are failing is a **terrible** idea. 😁 

First of all, the change that introduced the failure was https://github.com/travis-ci/packer-templates/commit/436ea3910f7048abdead177e313ef1d13c9b89cf, which seems correct and makes me think we weren't properly checking the service before. (For the record, travis-build also uses `rabbitmq-server` as the service name to start)

Looking at the error, it seems that Serverspec is trying to run `bash -c service\ rabbitmq-server\ status\ \&\&\ service\ rabbitmq-server\ status\ \|\ egrep\ \'running\|online\'` to check `should be_running`, which fails on a regular ubuntu box with the same error too, unless it is run with `sudo` or as `root`.

Now, I initially expected that using `sudo: true` [on this line](https://github.com/travis-ci/packer-templates/blob/master/cookbooks/lib/features/rabbitmq_spec.rb#L24) should do the trick, but that hasn't been the case. I tried experimenting some more, in the hopes of forcing the command to be run with sudo, but to no avail:
- [Experimental commit](https://github.com/travis-ci/packer-templates/commit/b8a633feb511ce64f8223d7ebee694085fe82961#diff-136b6e00902fb4d78a22f17d1db11bd9R45)
- [Experimental result (failure)](https://travis-ci.org/travis-infrastructure/packer-build/jobs/299544076)

The only way around this was to run the check as an explicit command using sudo, but then I noticed this already happens [further down](https://github.com/travis-ci/packer-templates/blob/master/cookbooks/lib/features/rabbitmq_spec.rb#L29), so this test is redundant, which is why I opted for removing it.

## How can you test this?
✅  Check that image built successfully: https://travis-ci.org/travis-infrastructure/packer-build/builds/299629263 (with some additional travis-cookbooks fixes)
✅  Check that rabbitmq is still enabled in build vms: https://travis-ci.org/bogdanap/travis_production_test/builds/299649570

## What feedback would you like, if any?
I'm still curious to know how to convince Serverspec to run a default check as sudo and why all my `whoami` experiments linked above failed. 
Also, any other feedback is welcome, of course.
