### PR TITLE
Revert "Pin chef to version 13.5.3 when building trusty images (#535)"

### DIFF
--- a/ci-amethyst.yml
+++ b/ci-amethyst.yml
@@ -85,7 +85,6 @@ provisioners:
   inline: chmod 0644 /var/tmp/amethyst-system-info-commands.yml
 - type: chef-solo
   config_template: chef-solo.rb.tmpl
-  version: 13.5.3
   <% if ENV['CHEF_PROFILING'] %>
   execute_command: "{{if .Sudo}}sudo {{end}}CI=yes chef-solo -F doc --no-color -c {{.ConfigPath}} -j {{.JsonPath}}"
   <% end %>

--- a/ci-connie.yml
+++ b/ci-connie.yml
@@ -85,7 +85,6 @@ provisioners:
   inline: chmod 0644 /var/tmp/connie-system-info-commands.yml
 - type: chef-solo
   config_template: chef-solo.rb.tmpl
-  version: 13.5.3
   <% if ENV['CHEF_PROFILING'] %>
   execute_command: "{{if .Sudo}}sudo {{end}}CI=yes chef-solo -F doc --no-color -c {{.ConfigPath}} -j {{.JsonPath}}"
   <% end %>

--- a/ci-garnet.yml
+++ b/ci-garnet.yml
@@ -85,7 +85,6 @@ provisioners:
   inline: chmod 0644 /var/tmp/garnet-system-info-commands.yml
 - type: chef-solo
   config_template: chef-solo.rb.tmpl
-  version: 13.5.3
   <% if ENV['CHEF_PROFILING'] %>
   execute_command: "{{if .Sudo}}sudo {{end}}CI=yes chef-solo -F doc --no-color -c {{.ConfigPath}} -j {{.JsonPath}}"
   <% end %>


### PR DESCRIPTION
This reverts commit d0c54ba4ece459f8a0d1012753302170c5c25d62.

Chef have fixed their debian package format bug (https://github.com/chef/chef/issues/6549), so we can go back to using the latest version, as before.

Green builds all around 🎉:

https://travis-ci.org/travis-infrastructure/packer-build/builds/299707174
https://travis-ci.org/travis-infrastructure/packer-build/builds/299707134
https://travis-ci.org/travis-infrastructure/packer-build/builds/299707115