### PR TITLE
Bump versions of Python, nodejs & PHP

### DIFF
--- a/cookbooks/lib/languages/python_spec.rb
+++ b/cookbooks/lib/languages/python_spec.rb
@@ -39,8 +39,8 @@ describe 'python environment' do
   end
 
   {
-    'python2.7' => '2.7.13',
-    'python3.6' => '3.6.2'
+    'python2.7' => '2.7.14',
+    'python3.6' => '3.6.3'
   }.each do |python_alias, python_version|
     describe pycommand('python -m this', version: python_alias), dev: true do
       its(:stderr) { should be_empty }

--- a/cookbooks/travis_ci_amethyst/attributes/default.rb
+++ b/cookbooks/travis_ci_amethyst/attributes/default.rb
@@ -62,7 +62,7 @@ override['travis_java']['default_version'] = 'oraclejdk8'
 override['travis_java']['alternate_versions'] = []
 
 node_versions = %w[
-  6.11.3
+  6.12.0
 ]
 
 override['travis_build_environment']['nodejs_versions'] = node_versions

--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -14,14 +14,14 @@ override['travis_system_info']['commands_file'] = \
   '/var/tmp/garnet-system-info-commands.yml'
 
 php_versions = %w[
-  5.6.31
-  7.0.22
+  5.6.32
+  7.0.25
 ]
 override['travis_build_environment']['php_versions'] = php_versions
-override['travis_build_environment']['php_default_version'] = '5.6.31'
+override['travis_build_environment']['php_default_version'] = '5.6.32'
 override['travis_build_environment']['php_aliases'] = {
-  '5.6' => '5.6.31',
-  '7.0' => '7.0.22'
+  '5.6' => '5.6.32',
+  '7.0' => '7.0.25'
 }
 
 override['travis_perlbrew']['perls'] = []

--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -59,8 +59,8 @@ override['travis_build_environment']['nodejs_versions'] = node_versions
 override['travis_build_environment']['nodejs_default'] = node_versions.max
 
 pythons = %w[
-  2.7.13
-  3.6.2
+  2.7.14
+  3.6.3
 ]
 
 # Reorder pythons so that default python2 and python3 come first

--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -51,8 +51,8 @@ override['leiningen']['home'] = '/home/travis'
 override['leiningen']['user'] = 'travis'
 
 node_versions = %w[
-  6.11.3
-  8.4.0
+  6.12.0
+  8.9.1
 ]
 
 override['travis_build_environment']['nodejs_versions'] = node_versions

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -67,7 +67,7 @@ if node['kernel']['machine'] == 'ppc64le'
 end
 
 node_versions = %w[
-  6.11.3
+  6.12.0
 ]
 
 override['travis_build_environment']['nodejs_versions'] = node_versions

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -70,8 +70,8 @@ override['travis_build_environment']['nodejs_versions'] = node_versions
 override['travis_build_environment']['nodejs_default'] = node_versions.max
 
 pythons = %w[
-  2.7.13
-  3.6.2
+  2.7.14
+  3.6.3
 ]
 
 # Reorder pythons so that default python2 and python3 come first

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -62,8 +62,8 @@ override['leiningen']['home'] = '/home/travis'
 override['leiningen']['user'] = 'travis'
 
 node_versions = %w[
-  6.11.3
-  8.4.0
+  6.12.0
+  8.9.1
 ]
 
 override['travis_build_environment']['nodejs_versions'] = node_versions

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -14,14 +14,14 @@ override['travis_system_info']['commands_file'] = \
   '/var/tmp/sardonyx-system-info-commands.yml'
 
 php_versions = %w[
-  5.6.24
-  7.0.7
+  5.6.32
+  7.0.25
 ]
 override['travis_build_environment']['php_versions'] = php_versions
-override['travis_build_environment']['php_default_version'] = '5.6.24'
+override['travis_build_environment']['php_default_version'] = '5.6.32'
 override['travis_build_environment']['php_aliases'] = {
-  '5.6' => '5.6.24',
-  '7.0' => '7.0.7'
+  '5.6' => '5.6.32',
+  '7.0' => '7.0.25'
 }
 
 if node['kernel']['machine'] == 'ppc64le'


### PR DESCRIPTION
This is the packer-templates counterpart to travis-ci/travis-cookbooks#939.

This updates Python, nodejs and php to their latest patch versions. I've checked the Python versions are supported by pyenv 1.1.5, and that php-build supports the PHP versions and has had builds triggered on [php-src-builder](https://travis-ci.org/travis-ci/php-src-builder/builds/).

See individual commits for links to release notes.

Test builds of this + travis-ci/travis-cookbooks#939:
* [Connie](https://travis-ci.org/travis-infrastructure/packer-build/builds/300258655): ✅ 
* [Amethyst](https://travis-ci.org/travis-infrastructure/packer-build/builds/300260093): ✅ 
* [Garnet](https://travis-ci.org/travis-infrastructure/packer-build/builds/300259979): ✅ 
* [Stevonnie](https://travis-ci.org/travis-infrastructure/packer-build/builds/300260005): ✅ (ignoring travis-ci/packer-templates#544 and unrelated openstack failures)
* Opal: Waiting on Xenial retrigger of PHP 5.6.32 build (travis-ci/travis-ci#8737)
* Sardonyx: Waiting on Xenial retrigger of PHP 5.6.32 build (travis-ci/travis-ci#8737)

