### PR TITLE
Disable languages in Opal/Sardonyx that are causing failures

### DIFF
--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -98,9 +98,13 @@ override['travis_build_environment']['otp_releases'] = []
 override['travis_build_environment']['elixir_versions'] = []
 override['travis_build_environment']['default_elixir_version'] = ''
 
-# TODO: Remove the `|| true` once php-src-builder Xenial builds work:
+# TODO: Remove once php-src-builder Xenial builds work:
 # https://github.com/travis-ci/travis-ci/issues/8737
-if node['kernel']['machine'] == 'ppc64le' || true
+override['travis_build_environment']['php_versions'] = []
+override['travis_build_environment']['php_default_version'] = []
+override['travis_build_environment']['php_aliases'] = {}
+
+if node['kernel']['machine'] == 'ppc64le'
   override['travis_build_environment']['php_versions'] = []
   override['travis_build_environment']['php_default_version'] = []
   override['travis_build_environment']['php_aliases'] = {}

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -33,6 +33,12 @@ override['travis_perlbrew']['modules'] = %w[
 ]
 override['travis_perlbrew']['prerequisite_packages'] = []
 
+# TODO: Remove when perl-builder supports Xenial:
+# https://github.com/travis-ci/perl-builder/issues/3
+override['travis_perlbrew']['perls'] = []
+override['travis_perlbrew']['modules'] = []
+override['travis_perlbrew']['prerequisite_packages'] = []
+
 gimme_versions = %w[
   1.7.4
 ]

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -92,7 +92,15 @@ elixirs = %w[
   1.2.6
 ]
 
-if node['kernel']['machine'] == 'ppc64le'
+# TODO: Remove once travis-erlang-builder supports Xenial:
+# https://github.com/travis-ci/travis-erlang-builder/pull/6
+override['travis_build_environment']['otp_releases'] = []
+override['travis_build_environment']['elixir_versions'] = []
+override['travis_build_environment']['default_elixir_version'] = ''
+
+# TODO: Remove the `|| true` once php-src-builder Xenial builds work:
+# https://github.com/travis-ci/travis-ci/issues/8737
+if node['kernel']['machine'] == 'ppc64le' || true
   override['travis_build_environment']['php_versions'] = []
   override['travis_build_environment']['php_default_version'] = []
   override['travis_build_environment']['php_aliases'] = {}

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -92,12 +92,6 @@ elixirs = %w[
   1.2.6
 ]
 
-# TODO: Remove once travis-erlang-builder supports Xenial:
-# https://github.com/travis-ci/travis-erlang-builder/pull/6
-override['travis_build_environment']['otp_releases'] = []
-override['travis_build_environment']['elixir_versions'] = []
-override['travis_build_environment']['default_elixir_version'] = ''
-
 # TODO: Remove once php-src-builder Xenial builds work:
 # https://github.com/travis-ci/travis-ci/issues/8737
 override['travis_build_environment']['php_versions'] = []
@@ -112,6 +106,12 @@ end
 
 override['travis_build_environment']['elixir_versions'] = elixirs
 override['travis_build_environment']['default_elixir_version'] = elixirs.max
+
+# TODO: Remove once travis-erlang-builder supports Xenial:
+# https://github.com/travis-ci/travis-erlang-builder/pull/6
+override['travis_build_environment']['otp_releases'] = []
+override['travis_build_environment']['elixir_versions'] = []
+override['travis_build_environment']['default_elixir_version'] = ''
 
 override['travis_build_environment']['mercurial_install_type'] = 'pip'
 override['travis_build_environment']['mercurial_version'] = '4.2.2~trusty1'

--- a/cookbooks/travis_ci_opal/recipes/default.rb
+++ b/cookbooks/travis_ci_opal/recipes/default.rb
@@ -61,12 +61,12 @@ include_recipe 'travis_build_environment::elasticsearch'
 include_recipe 'travis_build_environment::xserver'
 if node['kernel']['machine'] != 'ppc64le'
   include_recipe 'travis_build_environment::google_chrome'
-  include_recipe 'travis_phantomjs'
+  # TODO: Uncomment when the Xenial phantomjs archive exists:
+  # https://s3.amazonaws.com/travis-phantomjs/binaries/ubuntu/16.04/x86_64/phantomjs-1.9.8.tar.bz2
+  # include_recipe 'travis_phantomjs'
 end
 include_recipe 'travis_build_environment::firefox'
-# TODO: Uncomment when the Xenial phantomjs archive exists:
-# https://s3.amazonaws.com/travis-phantomjs/binaries/ubuntu/16.04/x86_64/phantomjs-1.9.8.tar.bz2
-# include_recipe 'travis_phantomjs::2'
+include_recipe 'travis_phantomjs::2'
 
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'

--- a/cookbooks/travis_ci_opal/recipes/default.rb
+++ b/cookbooks/travis_ci_opal/recipes/default.rb
@@ -66,7 +66,7 @@ end
 include_recipe 'travis_build_environment::firefox'
 # TODO: Uncomment when the Xenial phantomjs archive exists:
 # https://s3.amazonaws.com/travis-phantomjs/binaries/ubuntu/16.04/x86_64/phantomjs-1.9.8.tar.bz2
-#include_recipe 'travis_phantomjs::2'
+# include_recipe 'travis_phantomjs::2'
 
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'

--- a/cookbooks/travis_ci_opal/recipes/default.rb
+++ b/cookbooks/travis_ci_opal/recipes/default.rb
@@ -64,7 +64,9 @@ if node['kernel']['machine'] != 'ppc64le'
   include_recipe 'travis_phantomjs'
 end
 include_recipe 'travis_build_environment::firefox'
-include_recipe 'travis_phantomjs::2'
+# TODO: Uncomment when the Xenial phantomjs archive exists:
+# https://s3.amazonaws.com/travis-phantomjs/binaries/ubuntu/16.04/x86_64/phantomjs-1.9.8.tar.bz2
+#include_recipe 'travis_phantomjs::2'
 
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -24,7 +24,9 @@ override['travis_build_environment']['php_aliases'] = {
   '7.0' => '7.0.7'
 }
 
-if node['kernel']['machine'] == 'ppc64le'
+# TODO: Remove the `|| true` once php-src-builder Xenial builds work:
+# https://github.com/travis-ci/travis-ci/issues/8737
+if node['kernel']['machine'] == 'ppc64le' || true
   override['travis_build_environment']['php_versions'] = []
   override['travis_build_environment']['php_default_version'] = []
   override['travis_build_environment']['php_aliases'] = {}
@@ -87,6 +89,10 @@ def python_aliases(full_name)
   return [nodash] unless nodash.include?('.')
   [nodash[0, 3]]
 end
+
+# TODO: Remove once cpython-builder supports Xenial:
+# https://github.com/travis-ci/cpython-builder/pull/25
+pythons = []
 
 override['travis_build_environment']['pythons'] = pythons
 pythons.each do |full_name|

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -54,7 +54,6 @@ override['java']['oracle']['jce']['enabled'] = true
 
 override['travis_java']['default_version'] = 'oraclejdk8'
 override['travis_java']['alternate_versions'] = %w[
-  openjdk7
   openjdk8
   oraclejdk9
 ]

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -113,6 +113,12 @@ rubies = %w[
 override['travis_build_environment']['default_ruby'] = rubies.reject { |n| n =~ /jruby/ }.max
 override['travis_build_environment']['rubies'] = rubies
 
+# TODO: Remove once travis-erlang-builder supports Xenial:
+# https://github.com/travis-ci/travis-erlang-builder/pull/6
+override['travis_build_environment']['otp_releases'] = []
+override['travis_build_environment']['elixir_versions'] = []
+override['travis_build_environment']['default_elixir_version'] = ''
+
 override['travis_build_environment']['update_hostname'] = false
 override['travis_build_environment']['use_tmpfs_for_builds'] = false
 

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -24,9 +24,13 @@ override['travis_build_environment']['php_aliases'] = {
   '7.0' => '7.0.7'
 }
 
-# TODO: Remove the `|| true` once php-src-builder Xenial builds work:
+# TODO: Remove once php-src-builder Xenial builds work:
 # https://github.com/travis-ci/travis-ci/issues/8737
-if node['kernel']['machine'] == 'ppc64le' || true
+override['travis_build_environment']['php_versions'] = []
+override['travis_build_environment']['php_default_version'] = []
+override['travis_build_environment']['php_aliases'] = {}
+
+if node['kernel']['machine'] == 'ppc64le'
   override['travis_build_environment']['php_versions'] = []
   override['travis_build_environment']['php_default_version'] = []
   override['travis_build_environment']['php_aliases'] = {}

--- a/cookbooks/travis_ci_sardonyx/recipes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/recipes/default.rb
@@ -67,7 +67,7 @@ end
 include_recipe 'travis_build_environment::firefox'
 # TODO: Uncomment when the Xenial phantomjs archive exists:
 # https://s3.amazonaws.com/travis-phantomjs/binaries/ubuntu/16.04/x86_64/phantomjs-1.9.8.tar.bz2
-#include_recipe 'travis_phantomjs::2'
+# include_recipe 'travis_phantomjs::2'
 
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'

--- a/cookbooks/travis_ci_sardonyx/recipes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/recipes/default.rb
@@ -62,12 +62,12 @@ include_recipe 'travis_build_environment::elasticsearch'
 include_recipe 'travis_build_environment::xserver'
 if node['kernel']['machine'] != 'ppc64le'
   include_recipe 'travis_build_environment::google_chrome'
-  include_recipe 'travis_phantomjs'
+  # TODO: Uncomment when the Xenial phantomjs archive exists:
+  # https://s3.amazonaws.com/travis-phantomjs/binaries/ubuntu/16.04/x86_64/phantomjs-1.9.8.tar.bz2
+  # include_recipe 'travis_phantomjs'
 end
 include_recipe 'travis_build_environment::firefox'
-# TODO: Uncomment when the Xenial phantomjs archive exists:
-# https://s3.amazonaws.com/travis-phantomjs/binaries/ubuntu/16.04/x86_64/phantomjs-1.9.8.tar.bz2
-# include_recipe 'travis_phantomjs::2'
+include_recipe 'travis_phantomjs::2'
 
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'

--- a/cookbooks/travis_ci_sardonyx/recipes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/recipes/default.rb
@@ -65,7 +65,9 @@ if node['kernel']['machine'] != 'ppc64le'
   include_recipe 'travis_phantomjs'
 end
 include_recipe 'travis_build_environment::firefox'
-include_recipe 'travis_phantomjs::2'
+# TODO: Uncomment when the Xenial phantomjs archive exists:
+# https://s3.amazonaws.com/travis-phantomjs/binaries/ubuntu/16.04/x86_64/phantomjs-1.9.8.tar.bz2
+#include_recipe 'travis_phantomjs::2'
 
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'


### PR DESCRIPTION
Currently the Opal/Sardonyx GCE builds are failing (examples: [opal](https://travis-ci.org/travis-infrastructure/packer-build/builds/300978422), [sardonyx](https://travis-ci.org/travis-infrastructure/packer-build/builds/300978432)) due to the custom built binaries for PHP/Erlang/Python/Perl/Phantomjs not being available for Xenial. (Note that the docker builds are failing sooner in the build process due to travis-ci/packer-templates#544)

This is problematic, since:
* It causes confusion/wasted time for contributors when master isn't passing.
* Perma-failing builds make it hard to determine whether other breakage is invisibly piling up behind those failures.
* Many of the Travis language custom builder repos use the language's image variant (eg `opal` in the case of travis-erlang-builder) to build the binary, so until that image builds successfully, there is a chicken-and-egg bootstrapping problem (one workaround is using the minimal images and manually installing dependencies, but these can then get out of sync with the actual images). See: https://github.com/travis-ci/travis-erlang-builder/pull/6#issuecomment-343755446

As such, these languages have been temporarily disabled to green up the Opal/Sardonyx images.

Something I spotted whilst working on this, is that PHP is being installed into Amethyst/Opal via the travis-cookbooks defaults, which actually include more PHP versions than the Garnet/Sardonyx images (which seems undesirable?).