### PR TITLE
Support PHP 7.1 by default

### DIFF
--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -21,7 +21,8 @@ override['travis_build_environment']['php_versions'] = php_versions
 override['travis_build_environment']['php_default_version'] = '5.6.32'
 override['travis_build_environment']['php_aliases'] = {
   '5.6' => '5.6.32',
-  '7.0' => '7.0.25'
+  '7.0' => '7.0.25',
+  '7.1' => '7.1.11'
 }
 
 override['travis_perlbrew']['perls'] = []

--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -16,6 +16,7 @@ override['travis_system_info']['commands_file'] = \
 php_versions = %w[
   5.6.32
   7.0.25
+  7.1.11
 ]
 override['travis_build_environment']['php_versions'] = php_versions
 override['travis_build_environment']['php_default_version'] = '5.6.32'

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -16,6 +16,7 @@ override['travis_system_info']['commands_file'] = \
 php_versions = %w[
   5.6.32
   7.0.25
+  7.1.11
 ]
 override['travis_build_environment']['php_versions'] = php_versions
 override['travis_build_environment']['php_default_version'] = '5.6.32'

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -21,7 +21,8 @@ override['travis_build_environment']['php_versions'] = php_versions
 override['travis_build_environment']['php_default_version'] = '5.6.32'
 override['travis_build_environment']['php_aliases'] = {
   '5.6' => '5.6.32',
-  '7.0' => '7.0.25'
+  '7.0' => '7.0.25',
+  '7.1' => '7.1.11'
 }
 
 if node['kernel']['machine'] == 'ppc64le'


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
https://github.com/travis-ci/packer-templates/issues/502

## What approach did you choose and why?
Since we already had the cookbook support for 7.1, we only needed to make sure it gets added to the actual image.

## How can you test this?
New dev image was successfully built: https://travis-ci.org/travis-infrastructure/packer-build/builds/304739183

Before build on `group: stable`: https://travis-ci.org/bogdanap/travis_production_test/jobs/304729908#L445
After - build on `group: dev`: https://travis-ci.org/bogdanap/travis_production_test/jobs/304729909#L445
