### PR TITLE
Green up Xenial Opal/Sardonyx GCE builds

### DIFF
--- a/cookbooks/lib/features/mongodb_spec.rb
+++ b/cookbooks/lib/features/mongodb_spec.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 def mongodb_service_name
-  return 'mongod' if `lsb_release -sc 2>/dev/null`.strip == 'trusty'
+  return 'mongod' if %w[trusty xenial].include?(Support.distro)
   'mongodb'
 end
 
 describe 'mongodb installation' do
   describe service(mongodb_service_name) do
+    # Note these will pass even if the service doesn't exist / has a different name.
+    # Unfortunately serverspec doesn't support `exists` for services, however the
+    # DB inserts below will at least fail if mongodb_service_name is incorrect.
     it { should_not be_enabled }
     it { should_not be_running }
   end

--- a/cookbooks/lib/support.rb
+++ b/cookbooks/lib/support.rb
@@ -46,6 +46,12 @@ module Support
 
   module_function :attributes
 
+  def distro
+    @distro ||= `lsb_release -sc 2>/dev/null`.strip
+  end
+
+  module_function :distro
+
   def libdir
     @libdir ||= Pathname.new(File.expand_path('../', __FILE__))
   end

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -33,12 +33,6 @@ override['travis_perlbrew']['modules'] = %w[
 ]
 override['travis_perlbrew']['prerequisite_packages'] = []
 
-# TODO: Remove when perl-builder supports Xenial:
-# https://github.com/travis-ci/perl-builder/issues/3
-override['travis_perlbrew']['perls'] = []
-override['travis_perlbrew']['modules'] = []
-override['travis_perlbrew']['prerequisite_packages'] = []
-
 gimme_versions = %w[
   1.7.4
 ]

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -126,6 +126,8 @@ override['travis_build_environment']['update_hostname'] = false
 override['travis_build_environment']['use_tmpfs_for_builds'] = false
 
 override['travis_packer_templates']['job_board']['stack'] = 'opal'
+
+# TODO: phantomjs (either make tests use phantomjs 2 or re-enable phantomjs 1)
 override['travis_packer_templates']['job_board']['features'] = %w[
   basic
   cassandra
@@ -146,7 +148,6 @@ override['travis_packer_templates']['job_board']['features'] = %w[
   nodejs_interpreter
   perl_interpreter
   perlbrew
-  phantomjs
   postgresql
   python_interpreter
   rabbitmq
@@ -156,6 +157,7 @@ override['travis_packer_templates']['job_board']['features'] = %w[
   sqlite
   xserver
 ]
+# TODO: erlang (travis-ci/travis-erlang-builder#6)
 override['travis_packer_templates']['job_board']['languages'] = %w[
   __opal__
   crystal
@@ -163,7 +165,6 @@ override['travis_packer_templates']['job_board']['languages'] = %w[
   d
   dart
   elixir
-  erlang
   haskell
   haxe
   julia

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -95,10 +95,6 @@ def python_aliases(full_name)
   [nodash[0, 3]]
 end
 
-# TODO: Remove once cpython-builder supports Xenial:
-# https://github.com/travis-ci/cpython-builder/pull/25
-pythons = []
-
 override['travis_build_environment']['pythons'] = pythons
 pythons.each do |full_name|
   override['travis_build_environment']['python_aliases'][full_name] = \

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -127,6 +127,7 @@ override['travis_build_environment']['mercurial_install_type'] = 'pip'
 override['travis_build_environment']['mercurial_version'] = '4.2.2~trusty1'
 
 override['travis_packer_templates']['job_board']['stack'] = 'sardonyx'
+# TODO: phantomjs (either make tests use phantomjs 2 or re-enable phantomjs 1)
 override['travis_packer_templates']['job_board']['features'] = %w[
   basic
   cassandra
@@ -147,7 +148,6 @@ override['travis_packer_templates']['job_board']['features'] = %w[
   nodejs_interpreter
   perl_interpreter
   perlbrew
-  phantomjs
   postgresql
   python_interpreter
   rabbitmq
@@ -157,6 +157,7 @@ override['travis_packer_templates']['job_board']['features'] = %w[
   sqlite
   xserver
 ]
+# TODO: php (travis-ci/travis-ci#8737)
 override['travis_packer_templates']['job_board']['languages'] = %w[
   __sardonyx__
   c
@@ -169,7 +170,6 @@ override['travis_packer_templates']['job_board']['languages'] = %w[
   groovy
   java
   node_js
-  php
   pure_java
   python
   ruby

--- a/packer-assets/opal-system-info-commands.yml
+++ b/packer-assets/opal-system-info-commands.yml
@@ -127,8 +127,6 @@ commands:
     command: curl http://localhost:7474/db/data 2>/dev/null
     pipe: perl -ne '/neo4j_version.*?([0-9\.]+)/ && print $1'
     post: service neo4j stop
-  - command: "/usr/local/phantomjs/bin/phantomjs --version"
-    name: PhantomJS version
   - command: dpkg -l
     name: Pre-installed PostgreSQL versions
     pipe: awk '$2 ~ /^postgresql-[0-9]+\.[0-9]+$/ {print $3}' | grep -E --only '^[^-]+'
@@ -143,9 +141,6 @@ commands:
     pipe: perl -n -e '/v=([\d\.]+)/ && {print "redis-server $1\n"}'
   - command: riak version
     name: riak version
-  - command: kerl list installations
-  - command: kiex list
-  - command: rebar --version
   - command: ls -l /usr/local/ghc
     name: ghc installations
   - command: perlbrew list

--- a/packer-assets/sardonyx-system-info-commands.yml
+++ b/packer-assets/sardonyx-system-info-commands.yml
@@ -127,8 +127,6 @@ commands:
     command: curl http://localhost:7474/db/data 2>/dev/null
     pipe: perl -ne '/neo4j_version.*?([0-9\.]+)/ && print $1'
     post: service neo4j stop
-  - command: "/usr/local/phantomjs/bin/phantomjs --version"
-    name: PhantomJS version
   - command: dpkg -l
     name: Pre-installed PostgreSQL versions
     pipe: awk '$2 ~ /^postgresql-[0-9]+\.[0-9]+$/ {print $3}' | grep -E --only '^[^-]+'
@@ -157,8 +155,6 @@ commands:
   - command: nvm list
     name: Pre-installed Node.js versions
     pipe: env GREP_COLORS='mt=01;32' egrep -o '(iojs-)?v[0-9\.]+' | sort | uniq
-  - command: phpenv versions
-  - command: composer --version
   - command: rvm list
     name: Pre-installed Ruby versions
     pipe: env GREP_COLORS='mt=01;32' egrep -o '(j?ruby|rbx|ree)-[^ ]+' | sort | uniq

--- a/packer-assets/ubuntu-xenial-ci-opal-docker-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-opal-docker-packages.txt
@@ -1,1 +1,2 @@
+chromium-browser
 uuid-dev

--- a/packer-assets/ubuntu-xenial-ci-opal-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-opal-packages.txt
@@ -31,6 +31,7 @@ bzip2
 bzr
 ca-certificates
 ccache
+chromium-browser
 command-not-found
 command-not-found-data
 console-setup

--- a/packer-assets/ubuntu-xenial-ci-sardonyx-docker-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-sardonyx-docker-packages.txt
@@ -1,1 +1,2 @@
+chromium-browser
 uuid-dev

--- a/packer-assets/ubuntu-xenial-ci-sardonyx-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-sardonyx-packages.txt
@@ -31,6 +31,7 @@ bzip2
 bzr
 ca-certificates
 ccache
+chromium-browser
 command-not-found
 command-not-found-data
 console-setup


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Fix specs on Xenial, hopefully making the GCE builds green.
(The Docker builds will still fail, see #544. Think it's best to handle separately.)

## What approach did you choose and why?

The previous PR (#549) stubbed out a number of languages that don't yet have builds available. However the specs then fail. I tried adding lots of `pending` annotations to the tests, however that got a little messy, so I instead removed the language/feature tags which stops the tests being run.

Since #549, both the Python and Perl archives for Xenial have been created, so this PR also re-enables Python on Sardonyx and Perl on Opal.

## How can you test this?

CI :-)

## What feedback would you like, if any?

Some help getting the remaining archive pieces merged/fixed would be great (these needn't block this PR):
* travis-ci/travis-erlang-builder#6 (though there's a gotcha with optional dependencies, see comments there)
* PHP: travis-ci/travis-ci#8737
* phantomjs (issue not yet filed)