### PR TITLE
Ensure specs that generate LoadErrors aren't silently skipped

### DIFF
--- a/cookbooks/lib/languages/node_js_spec.rb
+++ b/cookbooks/lib/languages/node_js_spec.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'features/nodejs_interpreter_spec'

--- a/cookbooks/lib/languages/nodejs_spec.rb
+++ b/cookbooks/lib/languages/nodejs_spec.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require 'features/nodejs_intepreter_spec'

--- a/cookbooks/lib/languages/ruby_spec.rb
+++ b/cookbooks/lib/languages/ruby_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'features/ruby_interpreter_spec'
-require 'features/rvm_spec'
-
 describe 'ruby installation' do
   describe command('gem --version') do
     its(:stderr) { should be_empty }
@@ -16,6 +13,6 @@ describe 'ruby installation' do
 
   describe command('rspec --version') do
     its(:stderr) { should be_empty }
-    its(:stdout) { should match(/^\d+\.\d+\.\d+/) }
+    its(:stdout) { should match(/^RSpec \d+\.\d+/) }
   end
 end

--- a/cookbooks/lib/support/job_board_tags.rb
+++ b/cookbooks/lib/support/job_board_tags.rb
@@ -15,8 +15,10 @@ module Support
           begin
             require spec_name
           rescue LoadError => e
-            $stderr.puts "TODO: missing #{spec_name}" unless draconian?
-            raise e if draconian?
+            # The path must be checked to ensure the LoadError is not
+            # from a broken require within the file being loaded.
+            raise e if draconian? || e.path != spec_name
+            $stderr.puts "TODO: missing #{spec_name}"
           end
         end
       end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Currently if one of the language/feature specs results in a `LoadError`, it is treated the same as if the spec didn't exist at all (ie the spec is skipped). Currently `ruby_spec.rb` is skipped due to this:
```
TODO: missing languages/ruby_spec
```
(See https://travis-ci.org/travis-ci/packer-templates/builds/308609853#L1011)

In addition, the `nodejs_spec.rb` is currently not being run since it doesn't match the language tag name of `node_js` (note the underscore):
```
TODO: missing languages/node_js_spec
```
(See https://travis-ci.org/travis-ci/packer-templates/builds/308609853#L1009)

## What approach did you choose and why?

Fix the currently broken specs and made `load_specs` check the `LoadError` is for the `require`d spec and not a nested import. For the node.js case, I don't think there's a better way of preventing incorrectly named specs, unless the current implementation is changed to one that enforces a spec always exists (but this isn't ideal given some of the tags are aliases and so duplicates) or else an explicit whitelist used instead.

## How can you test this?

Check CI to see that the Ruby and node.js specs are no longer reported as `TODO: missing ...`.

## What feedback would you like, if any?

Thoughts about how to make this more resilient in the future (and if seen as something viable, a new issue filed with ideas).