### PR TITLE
Macos job-board registrar stuff!

### DIFF
--- a/bin/job-board-register-macos
+++ b/bin/job-board-register-macos
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+libdir = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+
+require 'job_board_registrar'
+require 'macos_tarballer'
+
+if $PROGRAM_NAME == __FILE__
+  JobBoardRegistrar.new(
+    MacosTarballer.new.generate!(argv: ARGV)
+  ).register!
+end

--- a/lib/macos_image_metadata_writer.rb
+++ b/lib/macos_image_metadata_writer.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'tmpdir'
+require 'yaml'
+
+class MacosImageMetadataWriter
+  def initialize(image_name: '', osx_image: '', is_default: false)
+    @image_name = image_name
+    @osx_image = osx_image
+    @is_default = is_default
+  end
+
+  attr_reader :image_name, :osx_image, :is_default
+  private :image_name
+  private :osx_image
+  private :is_default
+
+  def write(tarball_dest)
+    # TODO: write {something} that passes along is_default
+
+    tmp_dir = Dir.mktmpdir(%w[job-board-registrar-macos- -tmp])
+    metadata_dir = File.join(tmp_dir, File.basename(tarball_dest, '.tar.bz2'))
+    FileUtils.mkdir_p(metadata_dir)
+
+    File.write(
+      File.join(metadata_dir, 'job-board-register.yml'),
+      YAML.dump(job_board_register_hash)
+    )
+
+    env_dir = File.join(metadata_dir, 'env')
+    FileUtils.mkdir_p(env_dir)
+
+    {
+      'DIST' => 'macos',
+      'IMAGE_NAME' => image_name,
+      'PACKER_BUILDER_TYPE' => 'vmware'
+    }.each do |key, value|
+      File.write(File.join(env_dir, key), value)
+    end
+
+    Dir.chdir(tmp_dir) do
+      `tar -cjf #{tarball_dest} #{File.basename(metadata_dir)}`
+    end
+  ensure
+    FileUtils.rm_rf(tmp_dir) unless tmp_dir.nil?
+  end
+
+  private def job_board_register_hash
+    {
+      'tags' => {
+        'os' => 'osx'
+      },
+      'tags_string' => "os:osx,osx_image:#{osx_image}"
+    }
+  end
+end

--- a/lib/macos_tarballer.rb
+++ b/lib/macos_tarballer.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+require_relative 'env'
+
+class MacosTarballer
+  def generate!(argv: argv)
+    parse_argv!(argv)
+    create_contents!
+  end
+
+  private def parse_argv!(argv)
+    OptionParser.new do |opts|
+      opts.on(
+        '-n', '--image-name=IMAGE_NAME', String, 'name of the image'
+      ) do |v|
+        options[:image_name] = v.strip
+      end
+
+      opts.on(
+        '-O', '--osx-image=OSX_IMAGE', String, 'value for osx_image tag'
+      ) do |v|
+        options[:osx_image] = v.strip
+      end
+
+      opts.on(
+        '-d', '--output-dir=OUTPUT_DIR', String,
+        'output directory for the generated tarball'
+      ) do |v|
+        options[:output_dir] = v.strip
+      end
+
+      opts.on(
+        '-D', '--[no]-is-default',
+        'set the image as default for the infrastructure'
+      ) do |v|
+        options[:is_default] = v
+      end
+    end.parse!(argv)
+  end
+
+  private def create_contents!
+    image_metadata = ImageMetadata.new(
+      # stuffff
+    )
+
+    '/some/nonexistent/thing.tar.bz2'
+  end
+
+  private def options
+    @options ||= {
+      osx_image: 'notset'
+    }
+  end
+
+  private def env
+    @env ||= Env.new
+  end
+end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Registering a macOS image with job-board is historically a matter of `curl`ing around until it works correctly, which has lost its charm.

## What approach did you choose and why?

Create a fake metadata tarball for a mac image to integrate with the existing `./lib/job_board_registrar.rb` stuff.

## How can you test this?

Manually, against staging job-board :scream_cat: