### PR TITLE
Use a newer Trusty base image

### DIFF
--- a/ci-amethyst.yml
+++ b/ci-amethyst.yml
@@ -20,7 +20,7 @@ builders:
   image_description: Travis CI Amethyst
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1404-trusty-v20170619
+  source_image: ubuntu-1404-trusty-v20171115a
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-connie.yml
+++ b/ci-connie.yml
@@ -20,7 +20,7 @@ builders:
   image_description: Travis CI Connie
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1404-trusty-v20170619
+  source_image: ubuntu-1404-trusty-v20171115a
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-cookiecat.yml
+++ b/ci-cookiecat.yml
@@ -18,7 +18,7 @@ builders:
   image_description: Travis CI cookiecat
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1404-trusty-v20170330
+  source_image: ubuntu-1404-trusty-v20171115a
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-garnet.yml
+++ b/ci-garnet.yml
@@ -20,7 +20,7 @@ builders:
   image_description: Travis CI Garnet
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1404-trusty-v20170619
+  source_image: ubuntu-1404-trusty-v20171115a
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4


### PR DESCRIPTION
Since the Ubuntu source image for Trusty seemed to be a bit old, I thought it might be good to use the latest one before we roll-out the LST images.

In order to do that, I used the ubuntu version that's currently available in [GCE]( https://console.cloud.google.com/compute/imagesDetail/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20171115a?project=eco-emissary-99515&organizationId=928883094116).

⚠️  I don't know how the [gce-parity](https://cloud.docker.com/app/travisci/repository/docker/travisci/gce-parity/general) are currently built for docker, so left those alone. The latest build in that case seems to be 17 hours ago, so is it safe to assume those are already up to date?

Test image builds: 
✅ [garnet](https://travis-ci.org/travis-infrastructure/packer-build/jobs/311684066)
✅ [connie](https://travis-ci.org/travis-infrastructure/packer-build/builds/311696926)
✅ [cookiecat](https://travis-ci.org/travis-infrastructure/packer-build/builds/311696906)
✅ [amethyst](https://travis-ci.org/travis-infrastructure/packer-build/builds/311696911) - amethyst docker failing is a [known issue](https://github.com/travis-ci/packer-templates/issues/559)


