### PR TITLE
Green up more of the Xenial images

### DIFF
--- a/ci-opal.yml
+++ b/ci-opal.yml
@@ -43,16 +43,19 @@ builders:
   - "{{ .Image }}"
   - /sbin/init
   commit: true
-- type: openstack
-  name: openstack
-  flavor: m1.medium-travis-ci
-  image_name: "{{ user `image_name` }}"
-  ssh_username: ubuntu
-  networks:
-  <% ENV['OS_NETWORKS'].to_s.split(',').map(&:strip).each do |network| %>
-  - <%= network %>
-  <% end %>
-  source_image_name: "{{ user `openstack_source_image_name` }}"
+# Openstack builds disabled for failing with an error that's not possible to debug
+# until a fix for the Packer error reporting is released:
+# https://github.com/travis-ci/packer-templates/issues/555
+# - type: openstack
+#   name: openstack
+#   flavor: m1.medium-travis-ci
+#   image_name: "{{ user `image_name` }}"
+#   ssh_username: ubuntu
+#   networks:
+#   <% ENV['OS_NETWORKS'].to_s.split(',').map(&:strip).each do |network| %>
+#   - <%= network %>
+#   <% end %>
+#   source_image_name: "{{ user `openstack_source_image_name` }}"
 provisioners:
 - type: shell
   inline: sleep 10
@@ -79,7 +82,7 @@ provisioners:
   destination: /var/tmp/packages.txt
   only:
   - googlecompute
-  - openstack
+  # - openstack
 - type: file
   source: packer-assets/ubuntu-xenial-ci-opal-docker-packages.txt
   destination: /var/tmp/packages.txt

--- a/ci-opal.yml
+++ b/ci-opal.yml
@@ -60,6 +60,12 @@ provisioners:
   - googlecompute
 - type: shell
   inline: apt-get update -yqq && apt-get install sudo -yqq
+  # Delay script execution until after /sbin/init has cleared out /tmp,
+  # otherwise the uploaded script gets deleted before it can be run.
+  # TODO: Decide if the container startup command should be /bin/bash and the
+  # /sbin/init call made the first provision step instead of this workaround:
+  # https://github.com/travis-ci/packer-templates/issues/544#issuecomment-344971947
+  pause_before: 5s
   only:
   - docker
 - type: file

--- a/ci-opal.yml
+++ b/ci-opal.yml
@@ -116,7 +116,6 @@ provisioners:
   inline: chmod 0644 /var/tmp/opal-system-info-commands.yml
 - type: chef-solo
   config_template: chef-solo.rb.tmpl
-  version: 13.5.3
   <% if ENV['CHEF_PROFILING'] %>
   execute_command: "{{if .Sudo}}sudo {{end}}CI=yes chef-solo -F doc --no-color -c {{.ConfigPath}} -j {{.JsonPath}}"
   <% end %>

--- a/ci-opal.yml
+++ b/ci-opal.yml
@@ -39,7 +39,7 @@ builders:
   - -v
   - <%= Dir.pwd %>/tmp/packer-builder-tmp:/tmp
   - --privileged=true
-  - --storage-opt=size=11G
+  - --storage-opt=size=15G
   - "{{ .Image }}"
   - /sbin/init
   commit: true

--- a/ci-sardonyx.yml
+++ b/ci-sardonyx.yml
@@ -116,7 +116,6 @@ provisioners:
   inline: chmod 0644 /var/tmp/sardonyx-system-info-commands.yml
 - type: chef-solo
   config_template: chef-solo.rb.tmpl
-  version: 13.5.3
   <% if ENV['CHEF_PROFILING'] %>
   execute_command: "{{if .Sudo}}sudo {{end}}CI=yes chef-solo -F doc --no-color -c {{.ConfigPath}} -j {{.JsonPath}}"
   <% end %>

--- a/ci-sardonyx.yml
+++ b/ci-sardonyx.yml
@@ -43,16 +43,19 @@ builders:
   - "{{ .Image }}"
   - /sbin/init
   commit: true
-- type: openstack
-  name: openstack
-  flavor: m1.medium-travis-ci
-  image_name: "{{ user `image_name` }}"
-  ssh_username: ubuntu
-  networks:
-  <% ENV['OS_NETWORKS'].to_s.split(',').map(&:strip).each do |network| %>
-  - <%= network %>
-  <% end %>
-  source_image_name: "{{ user `openstack_source_image_name` }}"
+# Openstack builds disabled for failing with an error that's not possible to debug
+# until a fix for the Packer error reporting is released:
+# https://github.com/travis-ci/packer-templates/issues/555
+# - type: openstack
+#   name: openstack
+#   flavor: m1.medium-travis-ci
+#   image_name: "{{ user `image_name` }}"
+#   ssh_username: ubuntu
+#   networks:
+#   <% ENV['OS_NETWORKS'].to_s.split(',').map(&:strip).each do |network| %>
+#   - <%= network %>
+#   <% end %>
+#   source_image_name: "{{ user `openstack_source_image_name` }}"
 provisioners:
 - type: shell
   inline: sleep 10
@@ -79,7 +82,7 @@ provisioners:
   destination: /var/tmp/packages.txt
   only:
   - googlecompute
-  - openstack
+  # - openstack
 - type: file
   source: packer-assets/ubuntu-xenial-ci-sardonyx-docker-packages.txt
   destination: /var/tmp/packages.txt

--- a/ci-sardonyx.yml
+++ b/ci-sardonyx.yml
@@ -60,6 +60,12 @@ provisioners:
   - googlecompute
 - type: shell
   inline: apt-get update -yqq && apt-get install sudo -yqq
+  # Delay script execution until after /sbin/init has cleared out /tmp,
+  # otherwise the uploaded script gets deleted before it can be run.
+  # TODO: Decide if the container startup command should be /bin/bash and the
+  # /sbin/init call made the first provision step instead of this workaround:
+  # https://github.com/travis-ci/packer-templates/issues/544#issuecomment-344971947
+  pause_before: 5s
   only:
   - docker
 - type: file

--- a/ci-sardonyx.yml
+++ b/ci-sardonyx.yml
@@ -39,7 +39,7 @@ builders:
   - -v
   - <%= Dir.pwd %>/tmp/packer-builder-tmp:/tmp
   - --privileged=true
-  - --storage-opt=size=11G
+  - --storage-opt=size=15G
   - "{{ .Image }}"
   - /sbin/init
   commit: true

--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -43,16 +43,19 @@ builders:
   - "{{ .Image }}"
   - /sbin/init
   commit: true
-- type: openstack
-  name: openstack
-  flavor: m1.large-travis-ci
-  image_name: "{{ user `image_name` }}"
-  ssh_username: ubuntu
-  networks:
-  <% ENV['OS_NETWORKS'].to_s.split(',').map(&:strip).each do |network| %>
-  - <%= network %>
-  <% end %>
-  source_image_name: "{{ user `openstack_source_image_name` }}"
+# Openstack builds disabled for failing with an error that's not possible to debug
+# until a fix for the Packer error reporting is released:
+# https://github.com/travis-ci/packer-templates/issues/555
+# - type: openstack
+#   name: openstack
+#   flavor: m1.large-travis-ci
+#   image_name: "{{ user `image_name` }}"
+#   ssh_username: ubuntu
+#   networks:
+#   <% ENV['OS_NETWORKS'].to_s.split(',').map(&:strip).each do |network| %>
+#   - <%= network %>
+#   <% end %>
+#   source_image_name: "{{ user `openstack_source_image_name` }}"
 provisioners:
 - type: shell
   inline: sleep 10
@@ -79,7 +82,7 @@ provisioners:
   destination: /var/tmp/packages.txt
   only:
   - googlecompute
-  - openstack
+  # - openstack
 - type: file
   source: packer-assets/ubuntu-xenial-ci-stevonnie-docker-packages.txt
   destination: /var/tmp/packages.txt

--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -116,7 +116,6 @@ provisioners:
   inline: chmod 0644 /var/tmp/stevonnie-system-info-commands.yml
 - type: chef-solo
   config_template: chef-solo.rb.tmpl
-  version: 13.5.3
   <% if ENV['CHEF_PROFILING'] %>
   execute_command: "{{if .Sudo}}sudo {{end}}CI=yes chef-solo -F doc --no-color -c {{.ConfigPath}} -j {{.JsonPath}}"
   <% end %>

--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -60,6 +60,12 @@ provisioners:
   - googlecompute
 - type: shell
   inline: apt-get update -yqq && apt-get install sudo -yqq
+  # Delay script execution until after /sbin/init has cleared out /tmp,
+  # otherwise the uploaded script gets deleted before it can be run.
+  # TODO: Decide if the container startup command should be /bin/bash and the
+  # /sbin/init call made the first provision step instead of this workaround:
+  # https://github.com/travis-ci/packer-templates/issues/544#issuecomment-344971947
+  pause_before: 5s
   only:
   - docker
 - type: file


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

After #549 and #554, all three of the **GCE** Xenial images are green. However this leaves:
* the Docker variants failing after only a couple of minutes (#544)
* the Openstack builds not even starting properly (#555)

With this PR:
* the Docker builds now either succeed (in the case of Stevonnie) or else make it much further through the build (eg 50 minutes in, for Opal/Sardonyx)
* the Openstack builds are commented out, so as to not make everything appear broken on the [builds](https://travis-ci.org/travis-infrastructure/packer-build/builds) page
* the chef version has been unpinned, for parity with the Trusty builds (the pinning was just to temporarily work around an upstream Chef regression - see #546)
* the Docker storage allowance has been bumped for parity with the Trusty builds (I did this in the hope it would resolve the rabbitmq-server install hang, given https://github.com/travis-ci/packer-templates/pull/561#issuecomment-349372100 - but it didn't help)

I also tried to figure out why the Docker builds then fail during the rabbitmq-server install 50 minutes into the build (which is further than they've ever reached before), however it's still puzzling me (I can't tell if it's hanging or just hitting the default 15 minutes [chef APT timeout](https://docs.chef.io/resource_apt_package.html#properties)), so I thought I'd open this PR in the meantime in case it saves someone else duplication. 

Summary:

_BEFORE_ | GCE | Docker | Openstack
--- | --- | --- | ---
[Stevonnie](https://travis-ci.org/travis-infrastructure/packer-build/builds/311971990) | ✅  | :boom: | :boom:
[Opal](https://travis-ci.org/travis-infrastructure/packer-build/builds/311971916) | ✅  | :boom: | :boom:
[Sardonyx](https://travis-ci.org/travis-infrastructure/packer-build/builds/311971975) | ✅  | :boom: | :boom:

_AFTER_ | GCE | Docker | Openstack
--- | --- | --- | ---
[Stevonnie](https://travis-ci.org/travis-infrastructure/packer-build/builds/312014272) | ✅  | ✅ |  :heavy_minus_sign:
[Opal](https://travis-ci.org/travis-infrastructure/packer-build/builds/309649066) | ✅  | :x: |  :heavy_minus_sign:
[Sardonyx](https://travis-ci.org/travis-infrastructure/packer-build/builds/312014265) | ✅  | :x: |  :heavy_minus_sign:

## What approach did you choose and why?

For fixing the Docker builds not even starting provision, I chose option (1) from here:
https://github.com/travis-ci/packer-templates/issues/544#issuecomment-344971947
...since it seemed the least risky. I added a TODO to decide whether to try the other approaches.

For the Openstack builds, since the root cause can't be easily identified for now (due to the Packer error handling bug) it seemed best to just punt on it for now. I thought about trying to mark them as `allow_failures`, however setting it via `matrix` in the `.travis.yml` template would break `travis-packer-build` since it
disables auto-mode when `matrix` is defined:
https://github.com/travis-ci/travis-packer-build/blob/1b57c6cb3db1ec8853736cf52ecbb6184ad86cbb/lib/travis/packer_build/request_builder.rb#L50-L58
...as such commenting out seemed like the next best option.

For more details on all of the above, see the individual commit messages.

## How can you test this?

Links to test builds in the tables above.

## What feedback would you like, if any?

Confirmation on the approach chosen above, and any thoughts on why the Opal/Sardonyx Docker builds get stuck during the rabbitmq-server install, even though it succeeds just fine on GCE. (This PR can either wait for that to be fixed, or be merged sooner - I don't have a preference either way.)