### PR TITLE
Tag garnet with 'language: generic' as well

### DIFF
--- a/cookbooks/travis_ci_garnet/attributes/default.rb
+++ b/cookbooks/travis_ci_garnet/attributes/default.rb
@@ -133,6 +133,7 @@ override['travis_packer_templates']['job_board']['features'] = %w[
 ]
 override['travis_packer_templates']['job_board']['languages'] = %w[
   __garnet__
+  generic
   c
   c++
   clojure


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
https://github.com/travis-ci/packer-templates/issues/550

## What approach did you choose and why?
Add `generic` to the list of garnet languages, so that it will be tagged accordingly by job-board.

## How can you test this?
- ✅  build a new version of garnet: https://travis-ci.org/travis-infrastructure/packer-build/builds/312565075
- ✅  run a test build using `language: generic` and `group: dev` and make sure the image that gets selected is `garnet` instead of `sugilite` : https://travis-ci.org/bogdanap/travis_production_test/builds/312586012

## What feedback would you like, if any?
The other tags that were sugilite specific were 

```
language_legacy: 'true'
language_hhvm: 'true'
language_mega: 'true'
language_perl6: 'true'
feature_sphinxsearch: 'true'
```

Should we retag garnet/amethyst with those as well, or are they fine to still route to the old sugilite image?

