### PR TITLE
Fixed failing Cassandra tests and enabled packer test for power

### DIFF
--- a/cookbooks/lib/features/basic_spec.rb
+++ b/cookbooks/lib/features/basic_spec.rb
@@ -439,11 +439,9 @@ describe 'openssl installation' do
   end
 end
 
-if os[:arch] !~ /ppc64/
-  describe command('packer version') do
-    its(:stdout) { should match(/^Packer v\d/) }
-    its(:exit_status) { should eq 0 }
-  end
+describe command('packer version') do
+  its(:stdout) { should match(/^Packer v\d/) }
+  its(:exit_status) { should eq 0 }
 end
 
 describe command('psql --version') do

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -117,6 +117,9 @@ override['travis_build_environment']['mercurial_install_type'] = 'pip'
 override['travis_build_environment']['mercurial_version'] = '4.2.2~trusty1'
 
 override['travis_build_environment']['update_hostname'] = false
+if node['kernel']['machine'] == 'ppc64le'
+  override['travis_build_environment']['update_hostname'] = true
+end
 override['travis_build_environment']['use_tmpfs_for_builds'] = false
 
 override['travis_packer_templates']['job_board']['stack'] = 'opal'

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -117,6 +117,9 @@ override['travis_build_environment']['elixir_versions'] = []
 override['travis_build_environment']['default_elixir_version'] = ''
 
 override['travis_build_environment']['update_hostname'] = false
+if node['kernel']['machine'] == 'ppc64le'
+  override['travis_build_environment']['update_hostname'] = true
+end
 override['travis_build_environment']['use_tmpfs_for_builds'] = false
 
 override['travis_build_environment']['mercurial_install_type'] = 'pip'


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
- Cassandra tests were failing on power and logs pointed out that hostname was not resolvable, hence updated the chef recipe to update the hostname during the chef run
- Also enabled packer tests for power , depends on https://github.com/travis-ci/travis-cookbooks/pull/961
## What approach did you choose and why?
Tested on power VM using Openstack Setup

## How can you test this?

## What feedback would you like, if any?
Please let me know if setting attribute update_hostname to true is better way to handle it or hostname setting should be handled as part of the test. (As it is done for docker in cassandra_spec.rb)
