### PR TITLE
Clean up the output of `make stacks-short`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ all: $(META_FILES) $(PHP_PACKAGES_FILE) $(SYSTEM_INFO_COMMANDS_FILES)
 
 .PHONY: stacks-short
 stacks-short:
-	@$(MAKE) stacks | sed 's/-trusty//'
+	@$(MAKE) -s stacks | sed 's/-trusty//;s/-xenial//'
 
 .PHONY: stacks
 stacks: stacks-trusty stacks-xenial


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The `stacks-clean` target prints some `make` bits and doesn't strip `-xenial` suffix.

## What approach did you choose and why?

Tell `make` to stay quiet and strip both `-trusty` and `-xenial` suffixes.

## How can you test this?

Run it!