### PR TITLE
Ensure cloud-init script for hostname is non-EC2 compatible

### DIFF
--- a/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
+++ b/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
@@ -17,6 +17,7 @@ main() {
   local instance_id=notset
   local instance_ipv4=127.0.0.1
   local ec2_metadata='http://169.254.169.254/latest/meta-data'
+  local packet_metadata='https://metadata.packet.net/metadata'
 
   if curl -sfSL "${ec2_metadata}/instance-id" &>/dev/null; then
     curl -sSL "${ec2_metadata}/instance-id" >"${RUNDIR}/instance-id"
@@ -26,6 +27,17 @@ main() {
     curl -sSL "${ec2_metadata}/local-ipv4" \
       >"${RUNDIR}/instance-ipv4"
     instance_ipv4="$(cat "${RUNDIR}/instance-ipv4")"
+  fi
+
+  if curl -sFSL "${packet_metadata}" &>/dev/null; then
+    cur -sSL "${packet_metadata}" >"${RUNDIR}/metadata.json"
+    instance_id="$(jq -r .id <"${RUNDIR}/metadata.json" | cut -d- -f 1)"
+
+    instance_ipv4="$(
+      jq -r ".network.addresses | .[] | \
+        select(.address_family==4 and .public==false) | \
+        .address" <"${RUNDIR}/metadata.json"
+    )"
   fi
 
   instance_hostname="$(

--- a/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
+++ b/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
@@ -24,7 +24,7 @@ main() {
   local packet_metadata='https://metadata.packet.net/metadata'
 
   if curl --connect-timeout 3 -sfSL \
-     "${ec2_metadata}/instance-id" &>/dev/null; then
+    "${ec2_metadata}/instance-id" &>/dev/null; then
     curl -sSL "${ec2_metadata}/instance-id" >"${RUNDIR}/instance-id"
     instance_id="$(cat "${RUNDIR}/instance-id")"
     instance_id="${instance_id:0:9}"

--- a/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
+++ b/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
@@ -13,23 +13,20 @@ main() {
   fi
 
   local hosts_line
-  local instance_hostname
-  local instance_id
-  local instance_ipv4
+  local instance_hostname=localhost
+  local instance_id=notset
+  local instance_ipv4=127.0.0.1
+  local ec2_metadata='http://169.254.169.254/latest/meta-data'
 
-  local instance_id_url='http://169.254.169.254/latest/meta-data/instance-id'
-  if ! curl -sf "${instance_id_url}" &>/dev/null; then
-    echo 'No metadata API at 169.254.169.254; exiting' >&2
-    exit 0
+  if curl -sfSL "${ec2_metadata}/instance-id" &>/dev/null; then
+    curl -sSL "${ec2_metadata}/instance-id" >"${RUNDIR}/instance-id"
+    instance_id="$(cat "${RUNDIR}/instance-id")"
+    instance_id="${instance_id:0:9}"
+
+    curl -sSL "${ec2_metadata}/local-ipv4" \
+      >"${RUNDIR}/instance-ipv4"
+    instance_ipv4="$(cat "${RUNDIR}/instance-ipv4")"
   fi
-
-  curl -sSL "${instance_id_url}" >"${RUNDIR}/instance-id"
-  instance_id="$(cat "${RUNDIR}/instance-id")"
-  instance_id="${instance_id:0:9}"
-
-  curl -sSL 'http://169.254.169.254/latest/meta-data/local-ipv4' \
-    >"${RUNDIR}/instance-ipv4"
-  instance_ipv4="$(cat "${RUNDIR}/instance-ipv4")"
 
   instance_hostname="$(
     sed "s/___INSTANCE_ID___/${instance_id}/g" \

--- a/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
+++ b/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
@@ -8,7 +8,7 @@ main() {
   : "${RUNDIR:=/var/tmp/travis-run.d}"
 
   if [ ! -f "${RUNDIR}/instance-hostname.tmpl" ]; then
-    echo "Missing ${RUNDIR}/instance-hostname.tmpl"
+    echo "Missing ${RUNDIR}/instance-hostname.tmpl" >&2
     exit 0
   fi
 
@@ -17,8 +17,13 @@ main() {
   local instance_id
   local instance_ipv4
 
-  curl -sSL 'http://169.254.169.254/latest/meta-data/instance-id' \
-    >"${RUNDIR}/instance-id"
+  local instance_id_url='http://169.254.169.254/latest/meta-data/instance-id'
+  if ! curl -sf "${instance_id_url}" &>/dev/null; then
+    echo 'No metadata API at 169.254.169.254; exiting' >&2
+    exit 0
+  fi
+
+  curl -sSL "${instance_id_url}" >"${RUNDIR}/instance-id"
   instance_id="$(cat "${RUNDIR}/instance-id")"
   instance_id="${instance_id:0:9}"
 

--- a/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
+++ b/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
@@ -4,6 +4,10 @@
 set -o errexit
 
 main() {
+  if [[ ! "${QUIET}" ]]; then
+    set -o xtrace
+  fi
+
   : "${ETCDIR:=/etc}"
   : "${RUNDIR:=/var/tmp/travis-run.d}"
 
@@ -19,7 +23,8 @@ main() {
   local ec2_metadata='http://169.254.169.254/latest/meta-data'
   local packet_metadata='https://metadata.packet.net/metadata'
 
-  if curl -sfSL "${ec2_metadata}/instance-id" &>/dev/null; then
+  if curl --connect-timeout 3 -sfSL \
+     "${ec2_metadata}/instance-id" &>/dev/null; then
     curl -sSL "${ec2_metadata}/instance-id" >"${RUNDIR}/instance-id"
     instance_id="$(cat "${RUNDIR}/instance-id")"
     instance_id="${instance_id:0:9}"
@@ -29,8 +34,8 @@ main() {
     instance_ipv4="$(cat "${RUNDIR}/instance-ipv4")"
   fi
 
-  if curl -sFSL "${packet_metadata}" &>/dev/null; then
-    cur -sSL "${packet_metadata}" >"${RUNDIR}/metadata.json"
+  if curl --connect-timeout 3 -sfSL "${packet_metadata}" &>/dev/null; then
+    curl -sSL "${packet_metadata}" >"${RUNDIR}/metadata.json"
     instance_id="$(jq -r .id <"${RUNDIR}/metadata.json" | cut -d- -f 1)"
 
     instance_ipv4="$(


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The `10-set-hostname-from-template` script exits nonzero when run outside of EC2 where a metadata API is available at 169.254.169.254.

## What approach did you choose and why?

Exit early if no EC2 metadata API is found so that cloud-init can proceed.

## How can you test this?

Tested manually on Packet 👍 