### PR TITLE
Patch tfw trusty kernel

### DIFF
--- a/cookbooks/travis_tfw/recipes/default.rb
+++ b/cookbooks/travis_tfw/recipes/default.rb
@@ -34,6 +34,11 @@ package %w[
   xfsprogs
 ]
 
+execute 'add-apt-repository ppa:canonical-kernel-team/pti'
+execute 'apt-get update'
+execute 'apt dist-upgrade -y'
+execute 'apt-get autoremove'
+
 template '/usr/local/bin/travis-docker-volume-setup' do
   source 'travis-docker-volume-setup.sh.erb'
   owner 'root'

--- a/tfw.yml
+++ b/tfw.yml
@@ -76,7 +76,6 @@ provisioners:
   scripts:
   - packer-scripts/ensure-travis-user
   - packer-scripts/purge
-  - packer-scripts/install-ubuntu-mainline-kernel
   - packer-scripts/run-serverspecs
   - packer-scripts/cleanup
   - packer-scripts/minimize


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

EC2 worker hosts are running Trusty with kernel `4.9.6-040906-generic` (hardcoded AMI, previously rolled back due to [issues with google chrome driver on xenial](https://github.com/travis-ci/travis-ci/issues/8836)). They should be running xenial (as per master) with a patched `4.13.0` in order to address Meltdown (see [meta issue](https://github.com/travis-pro/security/issues/61)).

## What approach did you choose and why?

This PR adds the apt repository `ppa:canonical-kernel-team/pti` and removes installation of the Ubuntu mainline kernel.

## How can you test this?

SSH in and run https://github.com/raphaelsc/Am-I-affected-by-Meltdown

## What feedback would you like, if any?
