### PR TITLE
Bump ruby to 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ install:
     export TRAVIS_COOKBOOKS_TEST_BRANCH="$(cat .test-branch 2>/dev/null)";
   fi
 - export GIT_DESC="$(git describe --always --dirty --tags)"
-- rvm use 2.4.2 --install --binary --fuzzy
+- rvm use 2.5.0 --install --binary --fuzzy
+- gem update --system
 - bundle install --jobs=3 --retry=2 --path=vendor/bundle
 - ./bin/packer-build-install
 - ln -sv "${TRAVIS_BUILD_DIR}" "${TRAVIS_BUILD_DIR}/tmp/packer-chef-local"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Use of elder ruby release (2.4.2).

## What approach did you choose and why?

Use 2.5.0 instead, because it is the most recently-released version.

## How can you test this?

Do tests pass and stuff?