### PR TITLE
Update all GCE image references

### DIFF
--- a/ci-amethyst.yml
+++ b/ci-amethyst.yml
@@ -20,7 +20,7 @@ builders:
   image_description: Travis CI Amethyst
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1404-trusty-v20171115a
+  source_image: ubuntu-1404-trusty-v20180110
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-connie.yml
+++ b/ci-connie.yml
@@ -20,7 +20,7 @@ builders:
   image_description: Travis CI Connie
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1404-trusty-v20171115a
+  source_image: ubuntu-1404-trusty-v20180110
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-cookiecat.yml
+++ b/ci-cookiecat.yml
@@ -18,7 +18,7 @@ builders:
   image_description: Travis CI cookiecat
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1404-trusty-v20171115a
+  source_image: ubuntu-1404-trusty-v20180110
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-garnet.yml
+++ b/ci-garnet.yml
@@ -20,7 +20,7 @@ builders:
   image_description: Travis CI Garnet
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1404-trusty-v20171115a
+  source_image: ubuntu-1404-trusty-v20180110
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-opal.yml
+++ b/ci-opal.yml
@@ -21,7 +21,7 @@ builders:
   image_description: Travis CI opal
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1604-xenial-v20170815a
+  source_image: ubuntu-1604-xenial-v20180112
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-sardonyx.yml
+++ b/ci-sardonyx.yml
@@ -21,7 +21,7 @@ builders:
   image_description: Travis CI sardonyx
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1604-xenial-v20170815a
+  source_image: ubuntu-1604-xenial-v20180112
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -21,7 +21,7 @@ builders:
   image_description: Travis CI stevonnie
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1604-xenial-v20170815a
+  source_image: ubuntu-1604-xenial-v20180112
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/tfw.yml
+++ b/tfw.yml
@@ -30,7 +30,7 @@ builders:
   image_description: Travis Tiny Floating Whale
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1404-trusty-v20170330
+  source_image: ubuntu-1604-xenial-v20180112
   zone: us-central1-a
   image_name: "{{ user `gce_image_name` }}"
   machine_type: n1-standard-4


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The current images are based on pre-meltdown GCE images.

## What approach did you choose and why?

First, switch the `googlecompute` builder of `tfw` to use a xenial image, then `make update-gce-images` since it's available.

## How can you test this?

Tests pass?  Downstream images build (maybe?)?