### PR TITLE
Bulid a more full featured NAT host on GCE

### DIFF
--- a/.example-job-board-register-sardonyx.yml
+++ b/.example-job-board-register-sardonyx.yml
@@ -19,7 +19,8 @@ languages:
 - scala
 features:
 - basic
-- cassandra
+# FIXME: uncomment once working on xenial
+# - cassandra
 - chromium
 # FIXME: uncomment once working on xenial
 # - couchdb
@@ -43,7 +44,8 @@ features:
 - python_interpreter
 - rabbitmq
 - redis
-- riak
+# FIXME: uncomment once working on xenial
+# - riak
 - ruby_interpreter
 - sqlite
 - xserver

--- a/internal-nat.yml
+++ b/internal-nat.yml
@@ -1,26 +1,77 @@
 ---
 description: Travis CI Internal NAT template
 variables:
-  aws_access_key: "{{ env `AWS_ACCESS_KEY` }}"
-  aws_secret_key: "{{ env `AWS_SECRET_KEY` }}"
   gce_account_file: "{{ env `GCE_ACCOUNT_FILE` }}"
+  gce_image_name: nat-{{ timestamp }}-<%= git_desc %>
   gce_project_id: "{{ env `GCE_PROJECT_ID` }}"
-  subnet_id: "{{ env `TRAVIS_SUBNET_ID` }}"
-  vpc_id: "{{ env `TRAVIS_VPC_ID` }}"
+  travis_cookbooks_branch: "{{ env `TRAVIS_COOKBOOKS_BRANCH` }}"
+  travis_cookbooks_sha: "{{ env `TRAVIS_COOKBOOKS_SHA` }}"
+  <% if !ENV['PACKER_TEMPLATES_BRANCH'].to_s.empty? %>
+  clean_packer_templates_branch: <%= ENV['PACKER_TEMPLATES_BRANCH'].gsub(/[^-a-zA-Z0-9]/, '-').gsub(/^-/, '').gsub(/-$/, '') %>
+  <% else %>
+  clean_packer_templates_branch: notset
+  <% end %>
+  <% if !ENV['TRAVIS_COOKBOOKS_BRANCH'].to_s.empty? %>
+  clean_travis_cookbooks_branch: <%= ENV['TRAVIS_COOKBOOKS_BRANCH'].gsub(/[^-a-zA-Z0-9]/, '-').gsub(/^-/, '').gsub(/-$/, '') %>
+  <% else %>
+  clean_travis_cookbooks_branch: notset
+  <% end %>
 builders:
 - type: googlecompute
+  name: googlecompute
+  communicator: ssh
+  ssh_timeout: 10m
+  ssh_port: 22
+  ssh_username: nat
+  image_description: Travis NAT
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1404-trusty-v20170330
-  zone: us-central1-b
-  ssh_username: ubuntu
-  image_name: nat-{{ timestamp }}-<%= git_desc %>
-  machine_type: g1-small
+  source_image: ubuntu-1604-xenial-v20180112
+  zone: us-central1-a
+  image_name: "{{ user `gce_image_name` }}"
+  machine_type: n1-standard-4
   tags:
   - internal
   - nat
   - travis-ci-packer-templates
+  - "cookbooks-branch-{{ user `clean_travis_cookbooks_branch` }}"
+  - "branch-{{ user `clean_packer_templates_branch` }}"
 provisioners:
+- type: shell
+  inline:
+    sudo rm -rf /var/lib/apt/lists* ;
+    sudo apt-get update -yqq ;
+    sudo apt-get install -f
+- type: shell
+  scripts:
+  - packer-scripts/packer-env-dump
+  - packer-scripts/pre-chef-bootstrap
+  - packer-scripts/clone-travis-cookbooks
+  environment_vars:
+  - TRAVIS_COOKBOOKS_BRANCH={{ user `travis_cookbooks_branch` }}
+  - TRAVIS_COOKBOOKS_SHA={{ user `travis_cookbooks_sha` }}
+  execute_command: "{{ .Vars }} exec sudo -E -S bash '{{ .Path }}'"
+- type: chef-solo
+  config_template: chef-solo.rb.tmpl
+  cookbook_paths:
+  - cookbooks
+  remote_cookbook_paths:
+  - /tmp/chef-stuff/travis-cookbooks/cookbooks
+  - /tmp/chef-stuff/travis-cookbooks/community-cookbooks
+  run_list:
+  - recipe[travis_tfw]
+- type: shell
+  scripts:
+  - packer-scripts/ensure-travis-user
+  - packer-scripts/purge
+  - packer-scripts/install-ubuntu-mainline-kernel
+  - packer-scripts/run-serverspecs
+  - packer-scripts/cleanup
+  environment_vars:
+  - SPEC_SUITES=travis_internal_base,travis_tfw
+  - TRAVIS_OBFUSCATE_PASSWORD=1
+  - PURGE_PACKAGE_DEFAULTS=chef,chefdk
+  execute_command: "{{ .Vars }} exec sudo -E -S bash '{{ .Path }}'"
 - type: shell
   scripts:
   - packer-scripts/configure-nat

--- a/internal-nat.yml
+++ b/internal-nat.yml
@@ -59,7 +59,7 @@ provisioners:
   - /tmp/chef-stuff/travis-cookbooks/cookbooks
   - /tmp/chef-stuff/travis-cookbooks/community-cookbooks
   run_list:
-  - recipe[travis_tfw]
+  - recipe[travis_internal_base]
 - type: shell
   scripts:
   - packer-scripts/ensure-travis-user
@@ -68,7 +68,7 @@ provisioners:
   - packer-scripts/run-serverspecs
   - packer-scripts/cleanup
   environment_vars:
-  - SPEC_SUITES=travis_internal_base,travis_tfw
+  - SPEC_SUITES=travis_internal_base
   - TRAVIS_OBFUSCATE_PASSWORD=1
   - PURGE_PACKAGE_DEFAULTS=chef,chefdk
   execute_command: "{{ .Vars }} exec sudo -E -S bash '{{ .Path }}'"

--- a/packer-scripts/configure-nat
+++ b/packer-scripts/configure-nat
@@ -7,8 +7,7 @@ main() {
 
   export DEBIAN_FRONTEND=noninteractive
 
-  echo 1 >/proc/sys/net/ipv4/ip_forward
-  echo net.ipv4.ip_forward=1 >>/etc/sysctl.conf
+  sysctl -w net.ipv4.ip_forward=1
   iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
   iptables -A FORWARD -i eth0 -o eth1 -m state --state RELATED,ESTABLISHED -j ACCEPT
   iptables -A FORWARD -i eth1 -o eth0 -j ACCEPT


### PR DESCRIPTION
so that we are arguably in a better position to experiment and add more
stuff.

## What is the problem that this PR is trying to fix?

The current GCE NAT image is intentionally very stripped down, which means that we need to run extra steps if we ever want to SSH in and poke around.

## What approach did you choose and why?

Use the `travis_internal_base` cookbook bits to ensure users and access are set up.

## How can you test this?

Build it, deploy one in staging, ensure it is manageable over SSH.

## What feedback would you like, if any?
