### PR TITLE
Add support for instance name in instance hostname template

### DIFF
--- a/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
+++ b/cookbooks/travis_internal_base/files/default/10-set-hostname-from-template
@@ -19,6 +19,7 @@ main() {
   local hosts_line
   local instance_hostname=localhost
   local instance_id=notset
+  local instance_name=notset
   local region_zone=notset
   local instance_ipv4=127.0.0.1
   local ec2_metadata='http://169.254.169.254/latest/meta-data'
@@ -30,6 +31,7 @@ main() {
     curl -sSL "${ec2_metadata}/instance-id" >"${RUNDIR}/instance-id"
     instance_id="$(cat "${RUNDIR}/instance-id")"
     instance_id="${instance_id:0:9}"
+    instance_name="${instance_id}"
 
     curl -sSL "${ec2_metadata}/local-ipv4" \
       >"${RUNDIR}/instance-ipv4"
@@ -39,6 +41,7 @@ main() {
   if curl --connect-timeout 3 -sfSL "${packet_metadata}" &>/dev/null; then
     curl -sSL "${packet_metadata}" >"${RUNDIR}/metadata.json"
     instance_id="$(jq -r .id <"${RUNDIR}/metadata.json" | cut -d- -f 1)"
+    instance_name="${instance_id}"
 
     instance_ipv4="$(
       jq -r ".network.addresses | .[] | \
@@ -55,6 +58,10 @@ main() {
     instance_id="${instance_id:0:9}"
 
     curl -sSL -H 'Metadata-Flavor: Google' \
+      "${gce_metadata}/instance/name" >"${RUNDIR}/instance-name"
+    instance_name="$(cat "${RUNDIR}/instance-name")"
+
+    curl -sSL -H 'Metadata-Flavor: Google' \
       "${gce_metadata}/instance/network-interfaces/0/ip" \
       >"${RUNDIR}/instance-ipv4"
     instance_ipv4="$(cat "${RUNDIR}/instance-ipv4")"
@@ -67,6 +74,7 @@ main() {
 
   instance_hostname="$(
     sed -e "s/___INSTANCE_ID___/${instance_id}/g" \
+      -e "s/___INSTANCE_NAME___/${instance_name}/g" \
       -e "s/___REGION_ZONE___/${region_zone}/g" \
       <"${RUNDIR}/instance-hostname.tmpl"
   )"


### PR DESCRIPTION
specifically for use on GCE when each instances in instance groups where
the name assigned already contains useful bits in the prefix.