### PR TITLE
Disable and stop any APT periodic updates

### DIFF
--- a/cookbooks/travis_packer_templates/recipes/default.rb
+++ b/cookbooks/travis_packer_templates/recipes/default.rb
@@ -64,3 +64,13 @@ Array(node['travis_packer_templates']['packages']).each_slice(10) do |slice|
     action %i[install upgrade]
   end
 end
+
+%w[
+  apt-daily-upgrade.service
+  apt-daily-upgrade.timer
+  apt-daily.service
+  apt-daily.timer
+].each do |unit|
+  execute "systemctl disable #{unit}"
+  execute "systemctl stop #{unit}"
+end

--- a/packer-assets/ubuntu-xenial-normal-purge.txt
+++ b/packer-assets/ubuntu-xenial-normal-purge.txt
@@ -3,3 +3,4 @@ ppp
 pppconfig
 pppoeconf
 sshguard
+unattended-upgrades


### PR DESCRIPTION
and remove unattended-upgrades at purge time so that the likelihood of any `apt-daily.service` or `apt-daily-upgrade.service` running right after boot is further reduced (hopefully to zero).