### PR TITLE
Remove unattended-upgrades from ci packages lists

### DIFF
--- a/packer-assets/ubuntu-xenial-ci-opal-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-opal-packages.txt
@@ -461,7 +461,6 @@ ubuntu-release-upgrader-core
 ucf
 udev
 ufw
-unattended-upgrades
 unzip
 update-manager-core
 update-notifier-common

--- a/packer-assets/ubuntu-xenial-ci-sardonyx-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-sardonyx-packages.txt
@@ -461,7 +461,6 @@ ubuntu-release-upgrader-core
 ucf
 udev
 ufw
-unattended-upgrades
 unzip
 update-manager-core
 update-notifier-common

--- a/packer-assets/ubuntu-xenial-ci-stevonnie-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-stevonnie-packages.txt
@@ -461,7 +461,6 @@ ubuntu-release-upgrader-core
 ucf
 udev
 ufw
-unattended-upgrades
 unzip
 update-manager-core
 update-notifier-common


### PR DESCRIPTION
as it is not a package that we want on ci images due to the dpkg lock
fun that comes along.