### PR TITLE
Pin chef to version 13.8.5 for xenial images

### DIFF
--- a/ci-opal.yml
+++ b/ci-opal.yml
@@ -119,6 +119,7 @@ provisioners:
 - type: shell
   inline: chmod 0644 /var/tmp/opal-system-info-commands.yml
 - type: chef-solo
+  version: 13.8.5
   config_template: chef-solo.rb.tmpl
   <% if ENV['CHEF_PROFILING'] %>
   execute_command: "{{if .Sudo}}sudo {{end}}CI=yes chef-solo -F doc --no-color -c {{.ConfigPath}} -j {{.JsonPath}}"

--- a/ci-sardonyx.yml
+++ b/ci-sardonyx.yml
@@ -119,6 +119,7 @@ provisioners:
 - type: shell
   inline: chmod 0644 /var/tmp/sardonyx-system-info-commands.yml
 - type: chef-solo
+  version: 13.8.5
   config_template: chef-solo.rb.tmpl
   <% if ENV['CHEF_PROFILING'] %>
   execute_command: "{{if .Sudo}}sudo {{end}}CI=yes chef-solo -F doc --no-color -c {{.ConfigPath}} -j {{.JsonPath}}"

--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -119,6 +119,7 @@ provisioners:
 - type: shell
   inline: chmod 0644 /var/tmp/stevonnie-system-info-commands.yml
 - type: chef-solo
+  version: 13.8.5
   config_template: chef-solo.rb.tmpl
   <% if ENV['CHEF_PROFILING'] %>
   execute_command: "{{if .Sudo}}sudo {{end}}CI=yes chef-solo -F doc --no-color -c {{.ConfigPath}} -j {{.JsonPath}}"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Surprises with syntax errors that chef, e.g. https://travis-ci.org/travis-infrastructure/packer-build/jobs/378703178#L683

## What approach did you choose and why?
Pin it to a version from which I have seen it work.

## How can you test this?
Build an image.

## What feedback would you like, if any?
Is this a good version to pin to?