### PR TITLE
bundle exec travis-packer-build

### DIFF
--- a/bin/packer-build-trigger
+++ b/bin/packer-build-trigger
@@ -23,7 +23,7 @@ if [[ "${TRAVIS_COOKBOOKS_TEST_BRANCH}" ]]; then
 fi
 
 set -o xtrace
-exec travis-packer-build \
+bundle exec travis-packer-build \
   --chef-cookbook-path="${CHEF_COOKBOOK_PATH} ${TOP}/.git::cookbooks" \
   --packer-templates-path="${TOP}/.git::" \
   --commit-range="${TRAVIS_COMMIT_RANGE}" \


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Ran into this error:

```
% ./bin/packer-build-cookbooks-branch jvd-docker ci-stevonnie.yml
..../packer-templates/bin/packer-build-trigger: line 26: exec: travis-packer-build: not found
```
## What approach did you choose and why?
replaceing `exec` with `bundle exec` fixes it.

## How can you test this?
Use `./bin/packer-build-cookbooks-branch`.

## What feedback would you like, if any?
