### PR TITLE
Postgres

### DIFF
--- a/cookbooks/lib/features/postgresql_spec.rb
+++ b/cookbooks/lib/features/postgresql_spec.rb
@@ -4,7 +4,7 @@ include Support::Postgresql
 
 describe 'postgresql installation' do
   describe pgcommand('psql --version') do
-    its(:stdout) { should match(/^psql.+9\.[2-6]+\.[0-9]+/) }
+    its(:stdout) { should match(/^psql.+(9\.[4-6]+\.[0-9]+|10\.[0-9])/) }
     its(:exit_status) { should eq 0 }
   end
 

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -125,12 +125,9 @@ override['travis_build_environment']['use_tmpfs_for_builds'] = false
 
 override['travis_packer_templates']['job_board']['stack'] = 'opal'
 
-
 override['travis_postgresql']['default_version'] = '9.6'
 override['travis_postgresql']['alternate_versions'] = %w[9.4 9.5 10.4]
-
 override['travis_postgresql']['enabled'] = false # is default instance started on machine boot?
-
 
 # TODO: phantomjs (either make tests use phantomjs 2 or re-enable phantomjs 1)
 override['travis_packer_templates']['job_board']['features'] = %w[

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -125,6 +125,13 @@ override['travis_build_environment']['use_tmpfs_for_builds'] = false
 
 override['travis_packer_templates']['job_board']['stack'] = 'opal'
 
+
+override['travis_postgresql']['default_version'] = '9.6'
+override['travis_postgresql']['alternate_versions'] = %w[9.4 9.5 10.4]
+
+override['travis_postgresql']['enabled'] = false # is default instance started on machine boot?
+
+
 # TODO: phantomjs (either make tests use phantomjs 2 or re-enable phantomjs 1)
 override['travis_packer_templates']['job_board']['features'] = %w[
   basic

--- a/packer-assets/ubuntu-xenial-ci-opal-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-opal-packages.txt
@@ -372,7 +372,6 @@ pkg-config
 plymouth
 plymouth-theme-ubuntu-text
 pollinate
-postgresql-client
 powermgmt-base
 procps
 psmisc

--- a/packer-assets/ubuntu-xenial-ci-sardonyx-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-sardonyx-packages.txt
@@ -372,7 +372,6 @@ pkg-config
 plymouth
 plymouth-theme-ubuntu-text
 pollinate
-postgresql-client
 powermgmt-base
 procps
 psmisc

--- a/packer-assets/ubuntu-xenial-ci-stevonnie-docker-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-stevonnie-docker-packages.txt
@@ -5,5 +5,4 @@ hashdeep
 libmysqlclient-dev
 locales
 mysql-client
-postgresql-client
 uuid-dev

--- a/packer-assets/ubuntu-xenial-ci-stevonnie-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-stevonnie-packages.txt
@@ -372,7 +372,6 @@ pkg-config
 plymouth
 plymouth-theme-ubuntu-text
 pollinate
-postgresql-client
 powermgmt-base
 procps
 psmisc


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
* Support versions 9.4, 9.5, 9.6 and 10.4 out of the box.
* Make 9.6 the default.
* Fix a failing server spec by allowing the psql client to be 9.10
* Do not install postgresql-client as part of the package list, yet
  rely on the postgres recipe.

## What approach did you choose and why?
Override the defaults from travis-cookbooks. Relax the version matcher in the specs. Remove the client to be installed from the canonical apt repos.

## How can you test this?

## What feedback would you like, if any?
Are these the versions people are looking for?