### PR TITLE
Bump gce source image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ install:
 script:
 - make
 - bundle exec make test
+- make update-gce-images
 - git diff --exit-code
 - git diff --cached --exit-code
 - sudo lsof | grep dpkg || true

--- a/ci-opal.yml
+++ b/ci-opal.yml
@@ -21,7 +21,7 @@ builders:
   image_description: Travis CI opal
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1604-xenial-v20180112
+  source_image: ubuntu-1604-xenial-v20180522
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-sardonyx.yml
+++ b/ci-sardonyx.yml
@@ -21,7 +21,7 @@ builders:
   image_description: Travis CI sardonyx
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1604-xenial-v20180112
+  source_image: ubuntu-1604-xenial-v20180522
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -21,7 +21,7 @@ builders:
   image_description: Travis CI stevonnie
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1604-xenial-v20180112
+  source_image: ubuntu-1604-xenial-v20180522
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/tfw.yml
+++ b/tfw.yml
@@ -30,7 +30,7 @@ builders:
   image_description: Travis Tiny Floating Whale
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1604-xenial-v20180112
+  source_image: ubuntu-1604-xenial-v20180522
   zone: us-central1-a
   image_name: "{{ user `gce_image_name` }}"
   machine_type: n1-standard-4


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Make use of the new base image.

Additionally, this will fail the packer-templates build if a new image is available to ensure we keep on top of updates.

## What approach did you choose and why?
`make update-gce-images`

## How can you test this?

## What feedback would you like, if any?
Do we want to have the build fail on unrelated changes?