### PR TITLE
Ensure emacs is installed

### DIFF
--- a/bin/packer-build-trigger
+++ b/bin/packer-build-trigger
@@ -11,7 +11,8 @@ TOP="$(
 : "${TRAVIS_COOKBOOKS_GIT:=https://github.com/travis-ci/travis-cookbooks.git}"
 : "${CHEF_COOKBOOK_PATH:=${TRAVIS_COOKBOOKS_GIT}::cookbooks@master,community-cookbooks@master}"
 BODY_TMPL=${TOP}/.packer-build-pull-request-${TRAVIS_PULL_REQUEST}-tmpl.yml
-if [[ ! -f "${BODY_TMPL}" ]]; then BODY_TMPL=${TOP}/.packer-build-pull-request-tmpl.yml
+if [[ ! -f "${BODY_TMPL}" ]]; then
+  BODY_TMPL=${TOP}/.packer-build-pull-request-tmpl.yml
 fi
 
 if [[ "${TRAVIS_COOKBOOKS_TEST_BRANCH}" ]]; then

--- a/packer-assets/ubuntu-xenial-ci-opal-docker-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-opal-docker-packages.txt
@@ -1,3 +1,4 @@
 chromium-browser
+emacs-nox
 postgresql-client
 uuid-dev

--- a/packer-assets/ubuntu-xenial-ci-opal-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-opal-packages.txt
@@ -57,8 +57,7 @@ e2fsprogs
 eatmydata
 ed
 eject
-emacs
-emacs24-nox
+emacs-nox
 ethtool
 file
 findutils

--- a/packer-assets/ubuntu-xenial-ci-sardonyx-docker-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-sardonyx-docker-packages.txt
@@ -1,3 +1,4 @@
 chromium-browser
+emacs-nox
 postgresql-client
 uuid-dev

--- a/packer-assets/ubuntu-xenial-ci-sardonyx-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-sardonyx-packages.txt
@@ -57,8 +57,7 @@ e2fsprogs
 eatmydata
 ed
 eject
-emacs
-emacs24-nox
+emacs-nox
 ethtool
 file
 findutils

--- a/packer-assets/ubuntu-xenial-ci-stevonnie-docker-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-stevonnie-docker-packages.txt
@@ -1,6 +1,6 @@
 bridge-utils
 ccache
-emacs
+emacs-nox
 hashdeep
 libmysqlclient-dev
 locales

--- a/packer-assets/ubuntu-xenial-ci-stevonnie-packages.txt
+++ b/packer-assets/ubuntu-xenial-ci-stevonnie-packages.txt
@@ -56,8 +56,7 @@ e2fsprogs
 eatmydata
 ed
 eject
-emacs
-emacs24-nox
+emacs-nox
 ethtool
 file
 findutils


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Missing emacs caused a serverspec failure on docker builds.

## What approach did you choose and why?
* Remove specific versioning (24), to have the repositories decide on
the best candidate.
* Get the NoX version, as the dependency on xserver is not necessary.

## How can you test this?
https://travis-ci.org/travis-infrastructure/packer-build/builds/388159073
https://travis-ci.org/travis-infrastructure/packer-build/builds/388158987
https://travis-ci.org/travis-infrastructure/packer-build/builds/388158895

## What feedback would you like, if any?
