### PR TITLE
Stop using sudo for loading runner launchd plist

### DIFF
--- a/packer-scripts/macos-image-bootstrap
+++ b/packer-scripts/macos-image-bootstrap
@@ -321,7 +321,7 @@ EOF
 EOF
   sudo chown root ~/Library/LaunchAgents/com.travis-ci.runner.plist
   # needed because of newer security restrictions
-  sudo launchctl load ~/Library/LaunchAgents/com.travis-ci.runner.plist
+  launchctl load ~/Library/LaunchAgents/com.travis-ci.runner.plist
 }
 
 xcode_simulator_reset() {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

macOS images generated from Packer would timeout when trying to run a build because the runner.rb was not actually running.

## What approach did you choose and why?

The issue comes from the runner.rb.out and runner.rb.err files being owned by root instead of travis. This happens because the bootstrap script was loading the launchd job for the runner initially with `sudo`. This isn't actually necessary to do: since the travis user owns the job, they can load it without escalating privileges, and doing so causes the output files declared for the job to be created with the expected ownership.

## How can you test this?

I tested by booting the generated VM and verifying the runner was running, which wasn't true before. The more complete test of this would be to register the image with job-board and actually run a build against it.

## What feedback would you like, if any?

Anything you've got!