### PR TITLE
Improve make experience for building macOS images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,16 +29,16 @@ SED ?= sed
 TRAVIS_PACKER_BUILD ?= travis-packer-build
 UNZIP ?= unzip
 
-ci-macos: ci-macos.yml $(META_FILES)
-	$(PACKER) build -only=vsphere \
-		-var "xcode_version=$(XCODE)" \
-		<(bin/yml2json < $<)
-
 %: %.yml $(META_FILES)
 	$(PACKER) build -only=$(BUILDER) <(bin/yml2json < $<)
 
 .PHONY: all
 all: $(META_FILES) $(PHP_PACKAGES_FILE) $(SYSTEM_INFO_COMMANDS_FILES)
+
+ci-macos: ci-macos.yml $(META_FILES)
+	$(PACKER) build -only=vsphere \
+		-var "xcode_version=$(XCODE)" \
+		<(bin/yml2json < $<)
 
 .PHONY: stacks-short
 stacks-short:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ SED ?= sed
 TRAVIS_PACKER_BUILD ?= travis-packer-build
 UNZIP ?= unzip
 
+ci-macos: ci-macos.yml $(META_FILES)
+	$(PACKER) build -only=vsphere \
+		-var "xcode_version=$(XCODE)" \
+		<(bin/yml2json < $<)
+
 %: %.yml $(META_FILES)
 	$(PACKER) build -only=$(BUILDER) <(bin/yml2json < $<)
 

--- a/ci-macos.yml
+++ b/ci-macos.yml
@@ -40,6 +40,7 @@ provisioners:
   destination: /tmp/rvm-gpg.key
 - type: shell
   environment_vars:
+  - XCODE_VERSION={{ user `xcode_version` }}
   - XCODE_INSTALL_USER={{ user `xcode_install_user` }}
   - XCODE_INSTALL_PASSWORD={{ user `xcode_install_password` }}
   scripts:

--- a/packer-scripts/macos-image-bootstrap
+++ b/packer-scripts/macos-image-bootstrap
@@ -28,7 +28,7 @@ TRAVIS_SSH_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDEe8yPui0lLZpgaRNghw1H/2SG
 install_xcode() {
   echo "--- installing xcode"
   sudo gem install --no-document xcode-install
-  xcversion install $XCODE_VERSION
+  xcversion install "$XCODE_VERSION"
 
   echo "--- installing xcode command line tools"
   xcode-select -p &> /dev/null

--- a/packer-scripts/macos-image-bootstrap
+++ b/packer-scripts/macos-image-bootstrap
@@ -8,7 +8,6 @@ fi
 set -o errexit
 set -o pipefail
 
-declare -a XCODE_VERSION="9.4.1"
 IOS_VERSIONS="8.1,8.2,8.3,8.4,9.0,9.1,9.2,9.3,10.0,10.1,10.2,10.3"
 declare -a RUBIES=('2.3.5' '2.4.3')
 DEFAULT_RUBY="2.4.3"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

* Xcode version is hardcoded in the bootstrap script
* macOS always uses vSphere, but we have to pass it as `BUILDER=vsphere` in the command every time

Fixes travis-pro/team-build-env#29

## What approach did you choose and why?

Added an explicit make rule for 'ci-macos' instead of using the generic rule for the other YAML files. This new rule always passes vsphere as the builder, and expects you to pass `XCODE=<version>` on the command-line instead, which gets passed in as a variable to packer and exposed in the environment when running the bootstrap script.

## How can you test this?

Tested by running `make ci-macos XCODE=9.4.1` and seeing it install Xcode 9.4.1 in the logs from vsphere.

## What feedback would you like, if any?

Is this explicit rule a good idea? Is there a more general way to approach this problem?