### PR TITLE
Install a complete set of simulators

### DIFF
--- a/ci-macos.yml
+++ b/ci-macos.yml
@@ -23,11 +23,13 @@ builders:
   host: "packer_image_dev"
   datastore: "DataCore1_1"
   folder: "In Progress Base VMs"
-  template: "travis-ci-macos10.13-xcode9.4-vanilla"
+  template: "travis-ci-macos10.13-xcode9.4-vanilla-large"
   vm_name: "{{ user `image_name` }}"
+  # CPUs: 12
   CPUs: 2
   CPU_reservation: 0
   CPU_limit: 99999
+  # RAM: 32768
   RAM: 4096
   RAM_reservation: 0
   ssh_password: "{{ user `ssh_password` }}"

--- a/ci-macos.yml
+++ b/ci-macos.yml
@@ -25,7 +25,7 @@ builders:
   folder: "In Progress Base VMs"
   template: "travis-ci-macos10.13-xcode9.4-vanilla"
   vm_name: "{{ user `image_name` }}"
-  CPUs: 4
+  CPUs: 2
   CPU_reservation: 0
   CPU_limit: 99999
   RAM: 4096

--- a/ci-macos.yml
+++ b/ci-macos.yml
@@ -25,8 +25,9 @@ builders:
   folder: "In Progress Base VMs"
   template: "travis-ci-macos10.13-xcode9.4-vanilla"
   vm_name: "{{ user `image_name` }}"
-  CPUs: 2
+  CPUs: 4
   CPU_reservation: 0
+  CPU_limit: 99999
   RAM: 4096
   RAM_reservation: 0
   ssh_password: "{{ user `ssh_password` }}"

--- a/packer-scripts/macos-image-bootstrap
+++ b/packer-scripts/macos-image-bootstrap
@@ -8,10 +8,6 @@ fi
 set -o errexit
 set -o pipefail
 
-# We should change these to be computed dynamically based on the Xcode version
-IOS_VERSIONS="8.1,8.2,8.3,8.4,9.0,9.1,9.2,9.3,10.0,10.1,10.2,10.3,11.0,11.1,11.2,11.3"
-WATCHOS_VERSIONS="2.0,2.1,2.2,3.1,3.2,4.0,4.1,4.2"
-TVOS_VERSIONS="9.0,9.1,9.2,10.0,10.1,10.2,11.0,11.1,11.2,11.3"
 declare -a RUBIES=('2.3.5' '2.4.3')
 DEFAULT_RUBY="2.4.3"
 declare -a GEMS=('nomad-cli' 'cocoapods' 'bundler' 'rake' 'xcpretty' 'fastlane')
@@ -52,20 +48,10 @@ install_xcode() {
 
 install_xcode_simulators() {
   echo "--- Installing xcode simulators"
-  IFS=',' read -a IOS <<< $IOS_VERSIONS
-  for i in ${IOS[@]}; do
-    echo " --- Installing simulator for iOS $i"
-    echo "" | xcversion simulators --install="iOS $i"
-  done
-  IFS=',' read -a WATCHOS <<< $WATCHOS_VERSIONS
-  for i in ${WATCHOS[@]}; do
-    echo " --- Installing simulator for watchOS $i"
-    echo "" | xcversion simulators --install="watchOS $i"
-  done
-  IFS=',' read -a TVOS <<< $TVOS_VERSIONS
-  for i in ${TVOS[@]}; do
-    echo " --- Installing simulator for tvOS $i"
-    echo "" | xcversion simulators --install="tvOS $i"
+
+  xcversion simulators | grep 'not installed' | cut -d\  -f1,2 | while read -r line; do
+    echo " --- Installing simulator for $line"
+    echo "" | xcversion simulators --install="$line"
   done
 }
 

--- a/packer-scripts/macos-image-bootstrap
+++ b/packer-scripts/macos-image-bootstrap
@@ -49,9 +49,19 @@ install_xcode() {
 install_xcode_simulators() {
   echo "--- Installing xcode simulators"
 
+  local s=0
   xcversion simulators | grep 'not installed' | cut -d\  -f1,2 | while read -r line; do
-    echo " --- Installing simulator for $line"
-    echo "" | xcversion simulators --install="$line"
+    for i in {1..5}; do
+      echo " --- Installing simulator for $line (attempt $i)"
+      echo '' | xcversion simulators --install="$line" && break && s=0 || s=$? && sleep 5
+    done
+
+    # delete cached installer packages to free up disk space
+    rm ~/Library/Caches/XcodeInstall/*.{pkg,dmg}
+
+    if [ $s -ne 0 ]; then
+      exit $s
+    fi
   done
 }
 

--- a/packer-scripts/macos-image-bootstrap
+++ b/packer-scripts/macos-image-bootstrap
@@ -8,7 +8,10 @@ fi
 set -o errexit
 set -o pipefail
 
-IOS_VERSIONS="8.1,8.2,8.3,8.4,9.0,9.1,9.2,9.3,10.0,10.1,10.2,10.3"
+# We should change these to be computed dynamically based on the Xcode version
+IOS_VERSIONS="8.1,8.2,8.3,8.4,9.0,9.1,9.2,9.3,10.0,10.1,10.2,10.3,11.0,11.1,11.2,11.3"
+WATCHOS_VERSIONS="2.0,2.1,2.2,3.1,3.2,4.0,4.1,4.2"
+TVOS_VERSIONS="9.0,9.1,9.2,10.0,10.1,10.2,11.0,11.1,11.2,11.3"
 declare -a RUBIES=('2.3.5' '2.4.3')
 DEFAULT_RUBY="2.4.3"
 declare -a GEMS=('nomad-cli' 'cocoapods' 'bundler' 'rake' 'xcpretty' 'fastlane')
@@ -16,7 +19,7 @@ declare -a BREW_PKGS=('git' 'wget' 'mercurial' 'node' \
   'coreutils' 'postgresql' 'postgis' 'sqlite' 'go' 'gpg' 'carthage' \
   'md5deep' 'pyenv' 'tmate' 'cmake' 'maven' 'gpg2' 'gdbm')
 declare -a BREW_XCODE_PKGS=('xctool' 'swiftlint')
-declare -a BREW_CASK_PKGS=('java' 'oclint' 'rubymotion' 'xquartz')
+declare -a BREW_CASK_PKGS=('java' 'oclint' 'xquartz')
 declare -a PIP_PKGS=('virtualenv' 'numpy' 'scipy' 'tox')
 declare -a NODE_VERSIONS=('6' '5' '4')
 export NVM_VERSION="v0.33.2"
@@ -51,8 +54,18 @@ install_xcode_simulators() {
   echo "--- Installing xcode simulators"
   IFS=',' read -a IOS <<< $IOS_VERSIONS
   for i in ${IOS[@]}; do
-    echo " --- Installing simulator for ios $i"
+    echo " --- Installing simulator for iOS $i"
     echo "" | xcversion simulators --install="iOS $i"
+  done
+  IFS=',' read -a WATCHOS <<< $WATCHOS_VERSIONS
+  for i in ${WATCHOS[@]}; do
+    echo " --- Installing simulator for watchOS $i"
+    echo "" | xcversion simulators --install="watchOS $i"
+  done
+  IFS=',' read -a TVOS <<< $TVOS_VERSIONS
+  for i in ${TVOS[@]}; do
+    echo " --- Installing simulator for tvOS $i"
+    echo "" | xcversion simulators --install="tvOS $i"
   done
 }
 

--- a/packer-scripts/macos-image-bootstrap
+++ b/packer-scripts/macos-image-bootstrap
@@ -257,6 +257,9 @@ rvmrc_setup(){
 }
 
 rubies_install() {
+  # hack to get RVM to accept our binary even though GDBM updated version
+  ln -s /usr/local/opt/gdbm/lib/libgdbm.dylib /usr/local/opt/gdbm/lib/libgdbm.5.dylib
+
   echo "--- Install rubies with rvm"
   for RUBY in "${RUBIES[@]}"; do
     echo "--- Installing ruby version $RUBY"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Xcode 9.4 is missing some simulators that would be expected. This was caught by [testing Alamofire against xcode9.4](https://travis-ci.com/travis-infrastructure/Alamofire/builds/76747449).

## What approach did you choose and why?

For now, I'm explicitly listing the correct simulator versions, as it's quicker. I'm working on a change to automate figuring out the list of simulators to install, so that we can get this correct regardless of the XCODE version we pass in to make. That will be another PR.

This also tweaks some VM parameters and removes RubyMotion, since [it's unusable for our kind of set up](https://travisci.slack.com/archives/C02NECVA2/p1529503861000815)

## How can you test this?

We can run the Alamofire build again against the new image.

## What feedback would you like, if any?

Any.