### PR TITLE
Changes host parameter to use dedicated compute

### DIFF
--- a/ci-macos.yml
+++ b/ci-macos.yml
@@ -20,7 +20,7 @@ builders:
   password: "{{ user `vcenter_password` }}"
   insecure_connection: "{{ user `vcenter_insecure` }}"
   datacenter: "pod-1"
-  host: "MacPro_Pod_1"
+  host: "packer_image_dev"
   datastore: "DataCore1_1"
   folder: "In Progress Base VMs"
   template: "travis-ci-macos10.13-xcode9.4-vanilla"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

To improve packer build times in the pod-1 vsphere by giving it its own dedicated macpro with which to use 12 cores galore. 

## What approach did you choose and why?

## How can you test this?

## What feedback would you like, if any?
