### PR TITLE
Automate vSphere Mac image post-processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ CHEF_COOKBOOK_PATH := $(PWD)/.git::cookbooks \
 	$(TRAVIS_COOKBOOKS_GIT)::community-cookbooks@master \
 
 UNAME := $(shell uname | tr '[:upper:]' '[:lower:]')
+VSPHERE_IMAGES := $(shell command -v vsphere-images 2> /dev/null)
 
 BUILDER ?= googlecompute
 
@@ -36,6 +37,9 @@ UNZIP ?= unzip
 all: $(META_FILES) $(PHP_PACKAGES_FILE) $(SYSTEM_INFO_COMMANDS_FILES)
 
 ci-macos: ci-macos.yml $(META_FILES)
+ifndef VSPHERE_IMAGES
+	$(error "vsphere-images is not in the PATH. Please install it using `go get github.com/travis-ci/vsphere-images`")
+endif
 	$(PACKER) build -only=vsphere \
 		-var "xcode_version=$(XCODE)" \
 		<(bin/yml2json < $<)

--- a/bin/finalize-image-macos
+++ b/bin/finalize-image-macos
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+if [[ -z "$(which vsphere-images)" ]]; then
+  echo "Could not find vsphere-images tool in PATH. Exiting." >&2
+  exit 1
+fi
+
+VM_NAME="$1"
+NEW_VM_NAME="$2"
+
+ENCODED_USER=$(python -c "import urllib; print urllib.quote('''$VCENTER_USER''')")
+SOURCE_URL="https://${ENCODED_USER}:${VCENTER_PASSWORD}@${VCENTER_SERVER}/sdk"
+DESTINATION_URL="https://${ENCODED_USER}:${VCENTER_SECONDARY_PASSWORD}@${VCENTER_SECONDARY_SERVER}/sdk"
+
+SOURCE_DATACENTER="pod-1"
+DESTINATION_DATACENTER="pod-2"
+DESTINATION_DATASTORE="DataCore1_3"
+DESTINATION_POOL="MacPro_Pod_2"
+DESTINATION_HOST="10.88.242.51"
+DESTINATION_NETWORK="Jobs-2"
+
+NUM_CPUS=2
+CORES_PER_SOCKET=1
+RAM=4096
+
+IN_PROGRESS_FOLDER="In Progress Base VMs"
+FINAL_FOLDER="Base VMs"
+
+echo "Finalizing VM '${VM_NAME}' as '${NEW_VM_NAME}'"
+
+vsphere-images configure-image \
+  --vsphere-url="$SOURCE_URL" \
+  --vsphere-insecure-skip-verify \
+  --num-cpus=$NUM_CPUS \
+  --cores-per-socket=$CORES_PER_SOCKET \
+  --ram=$RAM \
+  "/$SOURCE_DATACENTER/vm/$IN_PROGRESS_FOLDER/$VM_NAME"
+
+vsphere-images move-image \
+  --vsphere-url="$SOURCE_URL" \
+  --vsphere-insecure-skip-verify \
+  "/$SOURCE_DATACENTER/vm/$IN_PROGRESS_FOLDER/${VM_NAME}" \
+  "/$SOURCE_DATACENTER/vm/$IN_PROGRESS_FOLDER/${NEW_VM_NAME}"
+
+vsphere-images copy-image \
+  --src-url="$SOURCE_URL" \
+  --dest-url="$DESTINATION_URL" \
+  --src-insecure-skip-verify \
+  --dest-insecure-skip-verify \
+  --dest-datastore-path="/$DESTINATION_DATACENTER/datastore/$DESTINATION_DATASTORE" \
+  --dest-pool-path="/$DESTINATION_DATACENTER/host/$DESTINATION_POOL" \
+  --dest-host-path="/$DESTINATION_DATACENTER/host/$DESTINATION_POOL/$DESTINATION_HOST" \
+  --dest-network-name="/$DESTINATION_DATACENTER/network/$DESTINATION_NETWORK" \
+  "/$SOURCE_DATACENTER/vm/$IN_PROGRESS_FOLDER/${NEW_VM_NAME}" \
+  "/$DESTINATION_DATACENTER/vm/$IN_PROGRESS_FOLDER/${NEW_VM_NAME}"
+
+vsphere-images resnapshot \
+  --vsphere-url="$SOURCE_URL" \
+  --vsphere-insecure-skip-verify \
+  "/$SOURCE_DATACENTER/vm/$IN_PROGRESS_FOLDER/$NEW_VM_NAME"
+
+vsphere-images resnapshot \
+  --vsphere-url="$DESTINATION_URL" \
+  --vsphere-insecure-skip-verify \
+  "/$DESTINATION_DATACENTER/vm/$IN_PROGRESS_FOLDER/$NEW_VM_NAME"
+
+vsphere-images move-image \
+  --vsphere-url="$SOURCE_URL" \
+  --vsphere-insecure-skip-verify \
+  "/$SOURCE_DATACENTER/vm/$IN_PROGRESS_FOLDER/${NEW_VM_NAME}" \
+  "/$SOURCE_DATACENTER/vm/$FINAL_FOLDER/${NEW_VM_NAME}"
+
+vsphere-images move-image \
+  --vsphere-url="$DESTINATION_URL" \
+  --vsphere-insecure-skip-verify \
+  "/$DESTINATION_DATACENTER/vm/$IN_PROGRESS_FOLDER/${NEW_VM_NAME}" \
+  "/$DESTINATION_DATACENTER/vm/$FINAL_FOLDER/${NEW_VM_NAME}"

--- a/ci-macos.yml
+++ b/ci-macos.yml
@@ -25,12 +25,10 @@ builders:
   folder: "In Progress Base VMs"
   template: "travis-ci-macos10.13-xcode9.4-vanilla-large"
   vm_name: "{{ user `image_name` }}"
-  # CPUs: 12
-  CPUs: 2
+  CPUs: 12             # will be changed later when finalized
   CPU_reservation: 0
   CPU_limit: 99999
-  # RAM: 32768
-  RAM: 4096
+  RAM: 32768           # will be changed later when finalized
   RAM_reservation: 0
   ssh_password: "{{ user `ssh_password` }}"
   shutdown_command: "sudo shutdown -h now"
@@ -49,3 +47,10 @@ provisioners:
   scripts:
   - packer-scripts/macos-image-bootstrap
   execute_command: "{{ .Vars }} bash -il '{{ .Path }}'"
+post-processors:
+- type: shell-local
+  environment_vars:
+  - IMAGE_NAME={{ user `image_name` }}
+  - FINAL_IMAGE_NAME=travis-ci-macos-10.13-xcode{{ user `xcode_version` }}-{{ timestamp }}
+  inline:
+  - bin/finalize-image-macos "$IMAGE_NAME" "$FINAL_IMAGE_NAME"


### PR DESCRIPTION
Oh my am I excited about this one!

## What is the problem that this PR is trying to fix?

Our current process for releasing macOS image involves a bunch of manual steps in the vSphere client to actually be ready to use a new image for builds. This PR should eliminate **all of them**.

## What approach did you choose and why?

I took our existing [vsphere-images](https://github.com/travis-ci/vsphere-images) tool and added two more commands to it for things we needed. I then created a script that will use `vsphere-images` to rename and reconfigure the VM, clone it into pod-2, snapshot them, and move them into the "Base VMs" folder.

That script (`bin/finalize-image-macos`) is now a Packer post-processor, so it will run automatically at the end of our Packer builds. By the end of the Packer build, we will have a VM image that we can register in job-board right away and start using!

The Makefile now checks if vsphere-images is in the PATH, which is to avoid building an entire VM and then having Packer destroy it when the post-processor fails.

## How can you test this?

I tested this first by running the finalize script against an arbitrary VM I created in pod-1. I then tested it as a Packer post-processor by commenting out the provisioner (to speed up the process of creating the VM) and running builds.

## What feedback would you like, if any?

Any!