### PR TITLE
Add scripts for check in/out of dedicated Mac host

### DIFF
--- a/bin/checkin-host-macos
+++ b/bin/checkin-host-macos
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+
+if [[ -z "$(which vsphere-images)" ]]; then
+  echo "Could not find vsphere-images tool in PATH. Exiting." >&2
+  exit 1
+fi
+
+ENCODED_USER=$(python -c "import urllib; print urllib.quote('''$VCENTER_USER''')")
+SOURCE_URL="https://${ENCODED_USER}:${VCENTER_PASSWORD}@${VCENTER_SERVER}/sdk"
+
+vsphere-images checkin-host \
+  --vsphere-url="$SOURCE_URL" \
+  --vsphere-insecure-skip-verify \
+  --dest-pool=/pod-1/host/MacPro_Pod_1 \
+  /pod-1/host/packer_image_dev

--- a/bin/checkout-host-macos
+++ b/bin/checkout-host-macos
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+
+if [[ -z "$(which vsphere-images)" ]]; then
+  echo "Could not find vsphere-images tool in PATH. Exiting." >&2
+  exit 1
+fi
+
+ENCODED_USER=$(python -c "import urllib; print urllib.quote('''$VCENTER_USER''')")
+SOURCE_URL="https://${ENCODED_USER}:${VCENTER_PASSWORD}@${VCENTER_SERVER}/sdk"
+
+vsphere-images checkout-host \
+  --vsphere-url="$SOURCE_URL" \
+  --vsphere-insecure-skip-verify \
+  --dest-pool=/pod-1/host/packer_image_dev \
+  /pod-1/host/MacPro_Pod_1


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

macOS Packer builds are configured to use a dedicated 'packer_image_dev'
host, but if we're not actively working on images, we want to leave that
host as part of the normal cluster. These scripts automate what parts we
can by using some new vsphere-images commands.

## What approach did you choose and why?

Added commands to vsphere-images for checking hosts in/out of the appropriate clusters (see travis-ci/vsphere-images#2). This PR just adds wrapper scripts that use the right env vars and cluster names.

## How can you test this?

Running the scripts!

## What feedback would you like, if any?

Any.