### PR TITLE
Update regex for pip version check to account for new versioning scheme

### DIFF
--- a/cookbooks/lib/languages/python_spec.rb
+++ b/cookbooks/lib/languages/python_spec.rb
@@ -13,7 +13,7 @@ describe 'python environment' do
 
   describe pycommand('pip --version') do
     its(:stderr) { should be_empty }
-    its(:stdout) { should match(/^pip \d+\.\d+\.\d+/) }
+    its(:stdout) { should match(/^pip \d+\.\d+(\.\d+)?/) }
   end
 
   describe pycommand('wheel version') do


### PR DESCRIPTION
It appears that pip has changed their versioning scheme [1] to be calendar based
and no symver (for whatever reason). This makes the third minor release optional
in case they decide to go back to the other version scheme.

[1] https://pip.pypa.io/en/stable/news/

## What is the problem that this PR is trying to fix?

The current ServerSpec regex fails when trying to test pip 18.0.

## What approach did you choose and why?

Making the minor version optional makes it more flexible down the road.

## How can you test this?

Built an image locally using this change.