### PR TITLE
Update packer version in install-packer target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ UNAME := $(shell uname | tr '[:upper:]' '[:lower:]')
 
 BUILDER ?= googlecompute
 
+PACKER_VERSION ?= 1.3.1
+
 CURL ?= curl
 GIT ?= git
 JQ ?= jq
@@ -82,7 +84,7 @@ update-gce-images:
 	bin/gce-image-update $$(git grep -lE 'source_image: ubuntu' *.yml)
 
 tmp/packer.zip:
-	$(CURL) -sSLo $@ 'https://releases.hashicorp.com/packer/1.1.0/packer_1.1.0_$(UNAME)_amd64.zip'
+	$(CURL) -sSLo $@ 'https://releases.hashicorp.com/packer/$(PACKER_VERSION)/packer_$(PACKER_VERSION)_$(UNAME)_amd64.zip'
 
 tmp/bats/.git:
 	$(GIT) clone https://github.com/sstephenson/bats.git tmp/bats

--- a/cookbooks/lib/features/basic_spec.rb
+++ b/cookbooks/lib/features/basic_spec.rb
@@ -309,7 +309,7 @@ end
 
 if os[:arch] !~ /ppc64/
   describe command('heroku version') do
-    its(:stdout) { should match(%r{^heroku-cli\/\d}) }
+    its(:stdout) { should match(%r{^heroku\/\d}) }
   end
 end
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

We are currently using an older Packer version

## What approach did you choose and why?

Make version configurable via env var `PACKER_VERSION`, defaulting to the current latest release 1.3.1.

## How can you test this?

    mkdir -p tmp
    make tmp/packer.zip
    env PACKER_VERSION=1.1.0 make tmp/packer.zip

## What feedback would you like, if any?

N/A