### PR TITLE
Make GITHUB_TOKEN available to image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ $(META_FILES): .git/HEAD
 	./bin/dump-git-meta ./tmp/git-meta
 	./bin/write-envdir $(PWD)/tmp/docker-meta 'DOCKER_LOGIN_(USERNAME|PASSWORD|SERVER)'
 	./bin/write-envdir $(PWD)/tmp/job-board-env 'JOB_BOARD'
-	./bin/write-envdir $(PWD)/tmp/github-token 'GITHUB_TOKEN'
 
 packer-assets/%-system-info-commands.yml: $(wildcard packer-assets/system-info.d/*.yml)
 	chmod 0600 $@

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ $(META_FILES): .git/HEAD
 	./bin/dump-git-meta ./tmp/git-meta
 	./bin/write-envdir $(PWD)/tmp/docker-meta 'DOCKER_LOGIN_(USERNAME|PASSWORD|SERVER)'
 	./bin/write-envdir $(PWD)/tmp/job-board-env 'JOB_BOARD'
+	./bin/write-envdir $(PWD)/tmp/github-token 'GITHUB_TOKEN'
 
 packer-assets/%-system-info-commands.yml: $(wildcard packer-assets/system-info.d/*.yml)
 	chmod 0600 $@

--- a/ci-opal.yml
+++ b/ci-opal.yml
@@ -11,6 +11,7 @@ variables:
   travis_cookbooks_edge_branch: master
   travis_cookbooks_sha: "{{ env `TRAVIS_COOKBOOKS_SHA` }}"
   travis_uid: "{{ env `TRAVIS_UID` }}"
+  github_token: "{{ env `GITHUB_TOKEN` }}"
 builders:
 - type: googlecompute
   name: googlecompute
@@ -134,7 +135,9 @@ provisioners:
   - /tmp/chef-stuff/travis-cookbooks/cookbooks
   - /tmp/chef-stuff/travis-cookbooks/community-cookbooks
   <% end %>
-  json: {}
+  json:
+    travis_packer_build:
+      github_token: "{{ user `github_token` }}"
   run_list:
   - recipe[travis_ci_opal]
   <% if ENV['CHEF_PROFILING'] %>

--- a/ci-sardonyx.yml
+++ b/ci-sardonyx.yml
@@ -11,6 +11,7 @@ variables:
   travis_cookbooks_edge_branch: master
   travis_cookbooks_sha: "{{ env `TRAVIS_COOKBOOKS_SHA` }}"
   travis_uid: "{{ env `TRAVIS_UID` }}"
+  github_token: "{{ env `GITHUB_TOKEN` }}"
 builders:
 - type: googlecompute
   name: googlecompute
@@ -134,7 +135,9 @@ provisioners:
   - /tmp/chef-stuff/travis-cookbooks/cookbooks
   - /tmp/chef-stuff/travis-cookbooks/community-cookbooks
   <% end %>
-  json: {}
+  json:
+    travis_packer_build:
+      github_token: "{{ user `github_token` }}"
   run_list:
   - recipe[travis_ci_sardonyx]
   <% if ENV['CHEF_PROFILING'] %>

--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -11,6 +11,7 @@ variables:
   travis_cookbooks_edge_branch: master
   travis_cookbooks_sha: "{{ env `TRAVIS_COOKBOOKS_SHA` }}"
   travis_uid: "{{ env `TRAVIS_UID` }}"
+  github_token: "{{ env `GITHUB_TOKEN` }}"
 builders:
 - type: googlecompute
   name: googlecompute
@@ -134,7 +135,9 @@ provisioners:
   - /tmp/chef-stuff/travis-cookbooks/cookbooks
   - /tmp/chef-stuff/travis-cookbooks/community-cookbooks
   <% end %>
-  json: {}
+  json:
+    travis_packer_build:
+      github_token: "{{ user `github_token` }}"
   run_list:
   - recipe[travis_ci_stevonnie]
   <% if ENV['CHEF_PROFILING'] %>


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Make GitHub token available to the build images to assist with obtaining the [newest nvm](https://github.com/travis-ci/travis-cookbooks/pull/998/commits/b77c72a682f1d0a8fe9fcca61c4f61c4ec1a52f0)
Part of https://github.com/travis-ci/travis-cookbooks/pull/998