### PR TITLE
Bump node + administrativia

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,6 @@ env:
   - SPEC_SUITES='travis_packer_templates'
   - SYSTEM_INFO_JSON="${TRAVIS_BUILD_DIR}/.example_system_info.json"
 install:
-# {
-# FIXME: remove these once addressed in sardonyx image
-- sudo systemctl disable apt-daily
-- sudo systemctl disable apt-daily.timer
-- sudo systemctl disable apt-daily-upgrade
-- sudo systemctl disable apt-daily-upgrade.timer
-- sudo systemctl stop apt-daily
-- sudo systemctl stop apt-daily-upgrade
-# }
 - if [[ -f .test-branch ]]; then
     export TRAVIS_COOKBOOKS_TEST_BRANCH="$(cat .test-branch 2>/dev/null)";
   fi

--- a/bin/gce-image-update
+++ b/bin/gce-image-update
@@ -50,4 +50,12 @@ __sed() {
   "${cmd[@]}"
 }
 
+__authenticate() {
+  [[ -z "$CI" ]] && return
+  local jsonfile
+  jsonfile="$(mktemp)"
+  echo "$GCE_ACCOUNT_FILE_B64_BZ2" | base64 --decode | bunzip2 >"$jsonfile"
+  gcloud auth activate-service-account "$GCE_ACCOUNT_FILE_ID" --key-file "$jsonfile"
+}
+
 main "$@"

--- a/ci-opal.yml
+++ b/ci-opal.yml
@@ -11,7 +11,7 @@ variables:
   travis_cookbooks_edge_branch: master
   travis_cookbooks_sha: "{{ env `TRAVIS_COOKBOOKS_SHA` }}"
   travis_uid: "{{ env `TRAVIS_UID` }}"
-  github_token: "{{ env `GITHUB_TOKEN` }}"
+  github_token: "{{ env `GITHUB_NOSCOPE_TOKEN` }}"
 builders:
 - type: googlecompute
   name: googlecompute

--- a/ci-opal.yml
+++ b/ci-opal.yml
@@ -22,7 +22,7 @@ builders:
   image_description: Travis CI opal
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1604-xenial-v20181004
+  source_image: ubuntu-1604-xenial-v20181023
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-sardonyx.yml
+++ b/ci-sardonyx.yml
@@ -11,7 +11,7 @@ variables:
   travis_cookbooks_edge_branch: master
   travis_cookbooks_sha: "{{ env `TRAVIS_COOKBOOKS_SHA` }}"
   travis_uid: "{{ env `TRAVIS_UID` }}"
-  github_token: "{{ env `GITHUB_TOKEN` }}"
+  github_token: "{{ env `GITHUB_NOSCOPE_TOKEN` }}"
 builders:
 - type: googlecompute
   name: googlecompute

--- a/ci-sardonyx.yml
+++ b/ci-sardonyx.yml
@@ -22,7 +22,7 @@ builders:
   image_description: Travis CI sardonyx
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1604-xenial-v20181004
+  source_image: ubuntu-1604-xenial-v20181023
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -11,7 +11,7 @@ variables:
   travis_cookbooks_edge_branch: master
   travis_cookbooks_sha: "{{ env `TRAVIS_COOKBOOKS_SHA` }}"
   travis_uid: "{{ env `TRAVIS_UID` }}"
-  github_token: "{{ env `GITHUB_TOKEN` }}"
+  github_token: "{{ env `GITHUB_NOSCOPE_TOKEN` }}"
 builders:
 - type: googlecompute
   name: googlecompute

--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -22,7 +22,7 @@ builders:
   image_description: Travis CI stevonnie
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1604-xenial-v20181004
+  source_image: ubuntu-1604-xenial-v20181023
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -64,12 +64,11 @@ else
   override['travis_jdk']['default'] = 'openjdk11'
 end
 
-node_versions = %w[
-  6.12.0
+override['travis_build_environment']['nodejs_versions'] = %w[
+  11.0.0
+  8.12.0
 ]
-
-override['travis_build_environment']['nodejs_versions'] = node_versions
-override['travis_build_environment']['nodejs_default'] = node_versions.max
+override['travis_build_environment']['nodejs_default'] = '8.12.0'
 
 override['travis_build_environment']['pythons'] = []
 

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -56,13 +56,11 @@ end
 override['leiningen']['home'] = '/home/travis'
 override['leiningen']['user'] = 'travis'
 
-node_versions = %w[
-  6.12.0
-  8.9.1
+override['travis_build_environment']['nodejs_versions'] = %w[
+  11.0.0
+  8.12.0
 ]
-
-override['travis_build_environment']['nodejs_versions'] = node_versions
-override['travis_build_environment']['nodejs_default'] = node_versions.max
+override['travis_build_environment']['nodejs_default'] = '8.12.0'
 
 pythons = %w[
   2.7.14

--- a/packer-assets/opal-system-info-commands.yml
+++ b/packer-assets/opal-system-info-commands.yml
@@ -115,12 +115,6 @@ commands:
   - command: mongod --version
     name: MongoDB version
     pipe: perl -n -e '/version v(.*)$/ && { print "MongoDB $1\n" }'
-  - pre: service neo4j restart
-    name: Neo4j version
-    port: 7474
-    command: curl http://localhost:7474/db/data 2>/dev/null
-    pipe: perl -ne '/neo4j_version.*?([0-9\.]+)/ && print $1'
-    post: service neo4j stop
   - command: dpkg -l
     name: Pre-installed PostgreSQL versions
     pipe: awk '$2 ~ /^postgresql-[0-9]+\.[0-9]+$/ {print $3}' | grep -E --only '^[^-]+'

--- a/packer-assets/sardonyx-system-info-commands.yml
+++ b/packer-assets/sardonyx-system-info-commands.yml
@@ -115,12 +115,6 @@ commands:
   - command: mongod --version
     name: MongoDB version
     pipe: perl -n -e '/version v(.*)$/ && { print "MongoDB $1\n" }'
-  - pre: service neo4j restart
-    name: Neo4j version
-    port: 7474
-    command: curl http://localhost:7474/db/data 2>/dev/null
-    pipe: perl -ne '/neo4j_version.*?([0-9\.]+)/ && print $1'
-    post: service neo4j stop
   - command: dpkg -l
     name: Pre-installed PostgreSQL versions
     pipe: awk '$2 ~ /^postgresql-[0-9]+\.[0-9]+$/ {print $3}' | grep -E --only '^[^-]+'

--- a/tfw.yml
+++ b/tfw.yml
@@ -30,7 +30,7 @@ builders:
   image_description: Travis Tiny Floating Whale
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
-  source_image: ubuntu-1604-xenial-v20181004
+  source_image: ubuntu-1604-xenial-v20181023
   zone: us-central1-a
   image_name: "{{ user `gce_image_name` }}"
   machine_type: n1-standard-4


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
- select Node versions that are available by default:
  - 8.12.0 (current LTS release, default)
  - 11.0.0 (current newest stable release)
- remove obsolete workarounds in .travis.yml
- authenticate gcloud for image comparer
- update gce base images
- remove neo4j from system-info-commands
- prevent accidental leaking of github tokens by not using the default variable name

## What approach did you choose and why?

## How can you test this?

## What feedback would you like, if any?
