### PR TITLE
Set default versions for ruby, perl, go

### DIFF
--- a/cookbooks/lib/features/go_toolchain_spec.rb
+++ b/cookbooks/lib/features/go_toolchain_spec.rb
@@ -10,7 +10,7 @@ end
 
 describe 'go toolchain installation' do
   describe command('go version') do
-    its(:stdout) { should match(/^go version go1\.[45678]/) }
+    its(:stdout) { should match(/^go version go/) }
   end
 
   describe command('go env GOROOT') do

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -34,7 +34,7 @@ override['travis_perlbrew']['modules'] = %w[
 override['travis_perlbrew']['prerequisite_packages'] = []
 
 gimme_versions = %w[
-  1.7.4
+  1.11.1
 ]
 
 override['travis_build_environment']['gimme']['versions'] = gimme_versions

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -12,9 +12,9 @@ override['travis_system_info']['commands_file'] = \
   '/var/tmp/opal-system-info-commands.yml'
 
 override['travis_perlbrew']['perls'] = [
-  { name: '5.22', version: 'perl-5.22.0' },
-  { name: '5.22-extras', version: 'perl-5.22.0',
-    arguments: '-Duseshrplib -Duseithreads', alias: '5.22-shrplib' },
+  { name: '5.26', version: 'perl-5.26.2' },
+  { name: '5.26-extras', version: 'perl-5.26.2',
+    arguments: '-Duseshrplib -Duseithreads', alias: '5.26-shrplib' },
   { name: '5.24', version: 'perl-5.24.0' },
   { name: '5.24-extras', version: 'perl-5.24.0',
     arguments: '-Duseshrplib -Duseithreads', alias: '5.24-shrplib' }

--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -73,8 +73,8 @@ override['travis_build_environment']['nodejs_default'] = '8.12.0'
 override['travis_build_environment']['pythons'] = []
 
 rubies = %w[
-  2.2.7
-  2.4.1
+  2.4.5
+  2.5.3
 ]
 
 override['travis_build_environment']['default_ruby'] = rubies.reject { |n| n =~ /jruby/ }.max

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -89,9 +89,9 @@ pythons.each do |full_name|
 end
 
 rubies = %w[
-  2.2.7
-  2.3.4
-  2.4.1
+  2.3.8
+  2.4.5
+  2.5.3
 ]
 
 override['travis_build_environment']['default_ruby'] = rubies.reject { |n| n =~ /jruby/ }.max

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -36,7 +36,7 @@ override['travis_perlbrew']['modules'] = []
 override['travis_perlbrew']['prerequisite_packages'] = []
 
 gimme_versions = %w[
-  1.7.4
+  1.11.1
 ]
 
 override['travis_build_environment']['gimme']['versions'] = gimme_versions

--- a/cookbooks/travis_ci_stevonnie/attributes/default.rb
+++ b/cookbooks/travis_ci_stevonnie/attributes/default.rb
@@ -11,7 +11,7 @@ override['travis_perlbrew']['modules'] = []
 override['travis_perlbrew']['prerequisite_packages'] = []
 
 gimme_versions = %w[
-  1.8.3
+  1.11.1
 ]
 
 override['travis_build_environment']['gimme']['versions'] = gimme_versions

--- a/cookbooks/travis_ci_stevonnie/attributes/default.rb
+++ b/cookbooks/travis_ci_stevonnie/attributes/default.rb
@@ -31,8 +31,8 @@ override['travis_system_info']['commands_file'] = \
   '/var/tmp/stevonnie-system-info-commands.yml'
 
 rubies = %w[
-  2.2.7
-  2.4.1
+  2.4.5
+  2.5.3
 ]
 
 override['travis_build_environment']['default_ruby'] = rubies.max


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Set default versions for ruby, perl, go
ruby: 2.4.5, 2.5.3 (default), 2.3.8 (only sardonyx)
perl: 5.24, 5.26, 5.24-extras, 5.26-extras
go: 1.11.1

## What approach did you choose and why?

## How can you test this?

## What feedback would you like, if any?
