### PR TITLE
Adding support for openstack build of "stevonnie" stack

### DIFF
--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -12,6 +12,9 @@ variables:
   travis_cookbooks_sha: "{{ env `TRAVIS_COOKBOOKS_SHA` }}"
   travis_uid: "{{ env `TRAVIS_UID` }}"
   github_token: "{{ env `GITHUB_NOSCOPE_TOKEN` }}"
+  openstack_zone: "{{ env `OS_ZONE` }}"
+  openstack_key_path: "{{ env `OS_SSH_KEY_PATH`}}"
+  openstack_key_name: "{{ env `OS_SSH_KEY` }}"
 builders:
 - type: googlecompute
   name: googlecompute
@@ -51,16 +54,20 @@ builders:
 # Openstack builds disabled for failing with an error that's not possible to debug
 # until a fix for the Packer error reporting is released:
 # https://github.com/travis-ci/packer-templates/issues/555
-# - type: openstack
-#   name: openstack
-#   flavor: m1.large-travis-ci
-#   image_name: "{{ user `image_name` }}"
-#   ssh_username: ubuntu
-#   networks:
-#   <% ENV['OS_NETWORKS'].to_s.split(',').map(&:strip).each do |network| %>
-#   - <%= network %>
-#   <% end %>
-#   source_image_name: "{{ user `openstack_source_image_name` }}"
+- type: openstack
+  name: openstack
+  flavor: m1.large
+  insecure: true
+  image_name: "{{ user `image_name` }}"
+  ssh_username: ubuntu
+  networks:
+  <% ENV['OS_NETWORKS'].to_s.split(',').map(&:strip).each do |network| %>
+  - <%= network %>
+  <% end %>
+  source_image_name: "{{ user `openstack_source_image_name` }}"
+  availability_zone: "{{ user `openstack_zone` }}"
+  ssh_keypair_name:  "{{ user `openstack_key_name` }}"
+  ssh_private_key_file: "{{ user `openstack_key_path`  }}"
 provisioners:
 - type: shell
   inline: sleep 10
@@ -87,7 +94,7 @@ provisioners:
   destination: /var/tmp/packages.txt
   only:
   - googlecompute
-  # - openstack
+  - openstack
 - type: file
   source: packer-assets/ubuntu-xenial-ci-stevonnie-docker-packages.txt
   destination: /var/tmp/packages.txt

--- a/ci-stevonnie.yml
+++ b/ci-stevonnie.yml
@@ -51,9 +51,6 @@ builders:
   - "{{ .Image }}"
   - /sbin/init
   commit: true
-# Openstack builds disabled for failing with an error that's not possible to debug
-# until a fix for the Packer error reporting is released:
-# https://github.com/travis-ci/packer-templates/issues/555
 - type: openstack
   name: openstack
   flavor: m1.large


### PR DESCRIPTION
- adding OS_ZONE,OS_SSH_KEY_PATH,OS_SSH_KEY environment variables
- re-enabling "openstack" as part of builders
- re-neabling "openstack" as part of provisioners

## What is the problem that this PR is trying to fix?
- This PR will allow creation of "stevonnie" stack base travis image for openstack backend . For this we are re-enabling support for openstack builder .

## What approach did you choose and why?
- Have tried this using packer
```
# packer --version
1.3.2
```
I tried this at OSU/OSL openstack based data-center using below packer command
```
# nohup packer build -on-error=abort -only=openstack <(bin/yml2json < ci-stevonnie.yml) > stevonnie_openstack &

# tail -f stevonnie_openstack
^[[0;32m    openstack: + tar -cjvf /var/tmp/image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty.tar.bz2 image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/node-attributes.yml^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/job-board-register.yml^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/travis_packer_templates_rspec.json^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/env/^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/env/PACKER_BUILD_NAME^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/env/TRAVIS_COOKBOOKS_SHA^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/env/TRAVIS_COOKBOOKS_DIR^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/env/PACKER_BUILDER_TYPE^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/bin-lib.SHA256SUMS^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/dpkg-manifest.json^[[0m
^[[0;32m    openstack: image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty/system_info.json^[[0m
^[[1;32m==> openstack: Downloading /var/tmp/image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty.tar.bz2 => tmp/image-metadata-travis-ci-stevonnie-xenial-1542177271-e193d27-dirty.tar.bz2^[[0m
^[[1;32m==> openstack: Stopping server: 3078de16-d19a-416a-b407-f0889a84d9cf ...^[[0m
^[[0;32m    openstack: Waiting for server to stop: 3078de16-d19a-416a-b407-f0889a84d9cf ...^[[0m
^[[1;32m==> openstack: Creating the image: travis-ci-stevonnie-xenial-1542177271-e193d27-dirty^[[0m
^[[0;32m    openstack: Image: 772b0f2c-4d1f-4948-8711-31daad8196ea^[[0m
^[[1;32m==> openstack: Waiting for image travis-ci-stevonnie-xenial-1542177271-e193d27-dirty (image id: 772b0f2c-4d1f-4948-8711-31daad8196ea) to become ready...^[[0m
^[[1;32m==> openstack: Terminating the source server: 3078de16-d19a-416a-b407-f0889a84d9cf ...^[[0m
^[[1;32m==> openstack: Running post-processor: shell-local^[[0m
^[[1;32m==> openstack (shell-local): Running local shell script: bin/write-latest-image-name^[[0m
^[[0;32m    openstack (shell-local): time=2018-11-14T07:20:27Z outfile=/root/amit_packer_image_creation/latest_packer/forked_one/packer-templates/tmp/ci-stevonnie/latest-image-name template=ci-stevonnie latest_image_name=travis-ci-stevonnie-xenial-1542177271-e193d27-dirty^[[0m
^[[1;32mBuild 'openstack' finished.^[[0m

==> Builds finished. The artifacts of successful builds are:
--> openstack: An image was created: 772b0f2c-4d1f-4948-8711-31daad8196ea

```
## How can you test this?
Tested successfully by creating stevonnie stack images for "ppc64le" architecture at OSU/OSL. Once we have validated and confirmed the other stacks ( sardonyx/opal) working smoothly  , will raise PR's for other changes.
## What feedback would you like, if any?
None.
