### PR TITLE
Tag sardonyx with the generic language

### DIFF
--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -149,6 +149,7 @@ override['travis_packer_templates']['job_board']['languages'] = %w[
   cplusplus
   cpp
   default
+  generic
   go
   groovy
   java


### PR DESCRIPTION
`language: generic` causes an ancient image to be selected. This adds the `generic` language to the sardonyx stack.

Addresses the report in https://github.com/travis-ci/travis-cookbooks/pull/978.