### PR TITLE
Correct firefox spec

### DIFF
--- a/cookbooks/lib/features/firefox_spec.rb
+++ b/cookbooks/lib/features/firefox_spec.rb
@@ -1,20 +1,26 @@
 # frozen_string_literal: true
 
 describe 'firefox installation' do
-  describe command('firefox -v') do
+  describe command('sudo -u travis firefox -v') do
     its(:exit_status) { should eq 0 }
+    its(:stderr) { should be_empty }
   end
 
   describe 'firefox commands' do
     before do
-      Support.tmpdir.join('.mozilla/firefox').mkpath
-      sh("HOME=#{Support.tmpdir} DISPLAY=:99.0 firefox -CreateProfile test")
+      home = Support.tmpdir
+      profile = home.join('.mozilla/firefox')
+      profile.mkpath
+
+      sh("chown --recursive travis:travis #{home}")
+      sh("HOME=#{home} DISPLAY=:99.0 sudo -u travis firefox -CreateProfile test")
     end
 
     describe file(
       Support.tmpdir.join('.mozilla/firefox/profiles.ini')
     ) do
       its(:content) { should match(/^Name=test/) }
+      it { should exist }
     end
   end
 end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
```
Running Firefox as root in a regular user's session is not supported.  ($HOME is /home/travis which is owned by travis.)
```
in the serverspecs. Also commenting out xvfb dependent spec until full xvfb support arrives

## What approach did you choose and why?

## How can you test this?

## What feedback would you like, if any?
