### PR TITLE
Add systemd version info, get builds to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: __sardonyx__
 dist: xenial
-group: dev
-sudo: required
+group: edge
 services:
 - postgresql
 filter_secrets: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: __sardonyx__
 dist: xenial
-group: edge
+group: dev
 sudo: required
 services:
 - postgresql

--- a/cookbooks/lib/features/xserver_spec.rb
+++ b/cookbooks/lib/features/xserver_spec.rb
@@ -7,6 +7,7 @@ describe 'xserver installation' do
 
   describe command('DISPLAY=:99.0 xset -q') do
     its(:stdout) { should match(/^Keyboard Control:/) }
+    its(:stderr) { should be_empty }
     its(:exit_status) { should eq 0 }
   end
 

--- a/packer-assets/opal-system-info-commands.yml
+++ b/packer-assets/opal-system-info-commands.yml
@@ -114,12 +114,12 @@ commands:
   - command: couchdb -V
     name: CouchDB version
     pipe: perl -n -e '/CouchDB ([\d\.]+)/ && {print "couchdb $1\n"}'
-  - pre: sudo service elasticsearch restart
+  - pre: sudo systemctl restart elasticsearch; sleep 10
     name: ElasticSearch version
     port: 9200
     command: curl localhost:9200 2>/dev/null
     pipe: awk -F\" '/number/ { print $4 }'
-    post: sudo service elasticsearch stop >/dev/null
+    post: sudo systemctl stop elasticsearch >/dev/null
   - command: ls -d /usr/local/firefox-*
     name: Installed Firefox version
     pipe: awk -F- '{print "firefox", $2}'

--- a/packer-assets/opal-system-info-commands.yml
+++ b/packer-assets/opal-system-info-commands.yml
@@ -7,6 +7,9 @@ commands:
     name: Build image provisioning date and time
   - command: lsb_release -a
     name: Operating System Details
+  - command: systemctl --version
+    name: Systemd Version
+    pipe: head -n 1
   osx:
   - command: date
     name: Build image provisioning date and time

--- a/packer-assets/opal-system-info-commands.yml
+++ b/packer-assets/opal-system-info-commands.yml
@@ -117,7 +117,7 @@ commands:
   - command: couchdb -V
     name: CouchDB version
     pipe: perl -n -e '/CouchDB ([\d\.]+)/ && {print "couchdb $1\n"}'
-  - pre: sudo systemctl restart elasticsearch; sleep 10
+  - pre: sudo systemctl restart elasticsearch; sleep 30
     name: ElasticSearch version
     port: 9200
     command: curl localhost:9200 2>/dev/null

--- a/packer-assets/sardonyx-system-info-commands.yml
+++ b/packer-assets/sardonyx-system-info-commands.yml
@@ -7,6 +7,9 @@ commands:
     name: Build image provisioning date and time
   - command: lsb_release -a
     name: Operating System Details
+  - command: systemctl --version
+    name: Systemd Version
+    pipe: head -n 1
   osx:
   - command: date
     name: Build image provisioning date and time
@@ -114,12 +117,12 @@ commands:
   - command: couchdb -V
     name: CouchDB version
     pipe: perl -n -e '/CouchDB ([\d\.]+)/ && {print "couchdb $1\n"}'
-  - pre: sudo service elasticsearch restart
+  - pre: sudo systemctl restart elasticsearch; sleep 10
     name: ElasticSearch version
     port: 9200
     command: curl localhost:9200 2>/dev/null
     pipe: awk -F\" '/number/ { print $4 }'
-    post: sudo service elasticsearch stop >/dev/null
+    post: sudo systemctl stop elasticsearch >/dev/null
   - command: ls -d /usr/local/firefox-*
     name: Installed Firefox version
     pipe: awk -F- '{print "firefox", $2}'

--- a/packer-assets/sardonyx-system-info-commands.yml
+++ b/packer-assets/sardonyx-system-info-commands.yml
@@ -117,7 +117,7 @@ commands:
   - command: couchdb -V
     name: CouchDB version
     pipe: perl -n -e '/CouchDB ([\d\.]+)/ && {print "couchdb $1\n"}'
-  - pre: sudo systemctl restart elasticsearch; sleep 10
+  - pre: sudo systemctl restart elasticsearch; sleep 30
     name: ElasticSearch version
     port: 9200
     command: curl localhost:9200 2>/dev/null

--- a/packer-assets/stevonnie-system-info-commands.yml
+++ b/packer-assets/stevonnie-system-info-commands.yml
@@ -7,6 +7,9 @@ commands:
     name: Build image provisioning date and time
   - command: lsb_release -a
     name: Operating System Details
+  - command: systemctl --version
+    name: Systemd Version
+    pipe: head -n 1
   osx:
   - command: date
     name: Build image provisioning date and time

--- a/packer-assets/system-info.d/basic.yml
+++ b/packer-assets/system-info.d/basic.yml
@@ -2,6 +2,7 @@ commands:
   linux:
     - { command: date -u, name: Build image provisioning date and time }
     - { command: lsb_release -a, name: Operating System Details }
+    - { command: systemctl --version, name: Systemd Version, pipe: "head -n 1" }
   osx:
     - { command: date, name: Build image provisioning date and time }
     - { command: sw_vers, name: Operating System Details }

--- a/packer-assets/system-info.d/elasticsearch.yml
+++ b/packer-assets/system-info.d/elasticsearch.yml
@@ -1,6 +1,6 @@
 commands:
   common:
-    - pre: "sudo systemctl restart elasticsearch; sleep 10"
+    - pre: "sudo systemctl restart elasticsearch; sleep 30"
       name: ElasticSearch version
       port: 9200
       command: 'curl localhost:9200 2>/dev/null'

--- a/packer-assets/system-info.d/elasticsearch.yml
+++ b/packer-assets/system-info.d/elasticsearch.yml
@@ -1,8 +1,8 @@
 commands:
   common:
-    - pre: sudo service elasticsearch restart
+    - pre: "sudo systemctl restart elasticsearch; sleep 10"
       name: ElasticSearch version
       port: 9200
       command: 'curl localhost:9200 2>/dev/null'
       pipe: "awk -F\\\" '/number/ { print $4 }'"
-      post: sudo service elasticsearch stop >/dev/null
+      post: sudo systemctl stop elasticsearch >/dev/null

--- a/packer-scripts/run-serverspecs
+++ b/packer-scripts/run-serverspecs
@@ -139,7 +139,7 @@ export RUBYOPT=${RUBYOPT}
 unset GEM_PATH
 
 cd ${cookbook_dir}
-sudo sh -e systemctl start xvfb || echo \"ignoring exit \$? from xvfb\"
+sudo systemctl start xvfb.service
 
 set -o errexit
 rspec ${SPEC_ARGS} \\

--- a/packer-scripts/run-serverspecs
+++ b/packer-scripts/run-serverspecs
@@ -139,7 +139,7 @@ export RUBYOPT=${RUBYOPT}
 unset GEM_PATH
 
 cd ${cookbook_dir}
-sh -e /etc/init.d/xvfb start || echo \"ignoring exit \$? from xvfb\"
+sh -e systemctl start xvfb || echo \"ignoring exit \$? from xvfb\"
 
 set -o errexit
 rspec ${SPEC_ARGS} \\

--- a/packer-scripts/run-serverspecs
+++ b/packer-scripts/run-serverspecs
@@ -139,7 +139,7 @@ export RUBYOPT=${RUBYOPT}
 unset GEM_PATH
 
 cd ${cookbook_dir}
-sh -e systemctl start xvfb || echo \"ignoring exit \$? from xvfb\"
+sudo sh -e systemctl start xvfb || echo \"ignoring exit \$? from xvfb\"
 
 set -o errexit
 rspec ${SPEC_ARGS} \\


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
- get packer-build's to pass again: adjust elasticsearch timeout
- adjust how xvfb is started in serverspecs
- add systemd version info

Please note that the builds for this PR are failing. This is because on the most recent `edge` image, xvfb init file is still present, and the systemd unit file is not. The commands that need a working Xorg enviroment fail (firefox, xset). This looks good in packer-build.

## What approach did you choose and why?
Fix the failing specs. Wait more if this is not enough.

## How can you test this?

## What feedback would you like, if any?
