### PR TITLE
change the version check for packer

### DIFF
--- a/packer-assets/opal-system-info-commands.yml
+++ b/packer-assets/opal-system-info-commands.yml
@@ -58,7 +58,7 @@ commands:
     name: mysql version
   - command: openssl version
     name: openssl version
-  - command: packer version
+  - command: packer --version
     name: packer version
   - command: psql --version
     name: postgresql client version

--- a/packer-assets/sardonyx-system-info-commands.yml
+++ b/packer-assets/sardonyx-system-info-commands.yml
@@ -58,7 +58,7 @@ commands:
     name: mysql version
   - command: openssl version
     name: openssl version
-  - command: packer version
+  - command: packer --version
     name: packer version
   - command: psql --version
     name: postgresql client version

--- a/packer-assets/stevonnie-system-info-commands.yml
+++ b/packer-assets/stevonnie-system-info-commands.yml
@@ -58,7 +58,7 @@ commands:
     name: mysql version
   - command: openssl version
     name: openssl version
-  - command: packer version
+  - command: packer --version
     name: packer version
   - command: psql --version
     name: postgresql client version

--- a/packer-assets/system-info.d/basic.yml
+++ b/packer-assets/system-info.d/basic.yml
@@ -24,7 +24,7 @@ commands:
     - { command: hg version, name: mercurial version, pipe: "awk -F'[)(]' '$2~/version/{print $2; exit}'" }
     - { command: mysql --version, name: mysql version }
     - { command: openssl version, name: openssl version }
-    - { command: packer version, name: packer version }
+    - { command: packer --version, name: packer version }
     - { command: psql --version, name: postgresql client version }
     - { command: ragel -v, name: ragel version, pipe: "head -n 1" }
     - { command: ssh -V, name: ssh client version }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Fix for issue #664 

## What approach did you choose and why?
Instead of `packer version` the command is changed to `packer --version`. This is not stdout the warning message to install latest packer.

## How can you test this?

## What feedback would you like, if any?
