### PR TITLE
Exclude chromium-browser installation on ppc64le

### DIFF
--- a/cookbooks/lib/features/basic_spec.rb
+++ b/cookbooks/lib/features/basic_spec.rb
@@ -616,7 +616,11 @@ end
 
 describe 'travis_build_environment packages' do
   Support.base_packages.each do |package_name|
-    describe(package(package_name)) { it { should be_installed } }
+    if os[:arch] =~ /ppc64/ && package_name == 'chromium-browser'
+      describe(package(package_name)) { it { should_not be_installed } }
+    else
+      describe(package(package_name)) { it { should be_installed } }
+    end
   end
 end
 

--- a/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
+++ b/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
@@ -117,8 +117,8 @@ class TravisPackerTemplates
     packages_lines = ::File.readlines(packages_file)
     packages = packages_lines.map(&:strip).reject { |l| l =~ /^#/ }.uniq
     if RUBY_PLATFORM == 'powerpc64le-linux'
-      chromium_browser_index = packages.index("chromium-browser")
-      if chromium_browser_index != nil
+      chromium_browser_index = packages.index('chromium-browser')
+      if !chromium_browser_index.nil
         packages.delete_at(chromium_browser_index)
       end
     end

--- a/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
+++ b/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
@@ -118,7 +118,7 @@ class TravisPackerTemplates
     packages = packages_lines.map(&:strip).reject { |l| l =~ /^#/ }.uniq
     if RUBY_PLATFORM == 'powerpc64le-linux'
       chromium_browser_index = packages.index('chromium-browser')
-      if !chromium_browser_index.nil?
+      unless chromium_browser_index.nil?
         packages.delete_at(chromium_browser_index)
       end
     end

--- a/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
+++ b/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
@@ -118,7 +118,7 @@ class TravisPackerTemplates
     packages = packages_lines.map(&:strip).reject { |l| l =~ /^#/ }.uniq
     if RUBY_PLATFORM == 'powerpc64le-linux'
       chromium_browser_index = packages.index('chromium-browser')
-      if !chromium_browser_index.nil
+      if !chromium_browser_index.nil?
         packages.delete_at(chromium_browser_index)
       end
     end

--- a/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
+++ b/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
@@ -116,6 +116,12 @@ class TravisPackerTemplates
   def assign_packages_from_packages_file(packages_file)
     packages_lines = ::File.readlines(packages_file)
     packages = packages_lines.map(&:strip).reject { |l| l =~ /^#/ }.uniq
+    if RUBY_PLATFORM == 'powerpc64le-linux'
+      chromium_browser_index = packages.index("chromium-browser")
+      if chromium_browser_index != nil
+        packages.delete_at(chromium_browser_index)
+      end
+    end
     node.override['travis_packer_templates']['packages'] = packages
     Chef::Log.info("Loaded #{packages.length} packages from #{packages_file}")
   end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Packer build for ppc64le fails while installing chromium-browser dependency, this PR will fix this issue.

## What approach did you choose and why?
The chromium-browser package will be removed from the package list on ppc64le, and the basic_spec.rb will check for chromium-browser not being installed on ppc64le. This will skip installation and check for chromium-browser on ppc64le.

## How can you test this?
This was tested locally, no failures were observed on ppc64le with these changes.

## What feedback would you like, if any?
None.