### PR TITLE
Defer job_board metadata file creation

### DIFF
--- a/cookbooks/travis_ci_opal/recipes/default.rb
+++ b/cookbooks/travis_ci_opal/recipes/default.rb
@@ -25,7 +25,6 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 include_recipe 'travis_build_environment::apt'
-include_recipe 'travis_packer_templates'
 include_recipe 'travis_build_environment'
 include_recipe 'travis_build_environment::haskell' if node['kernel']['machine'] != 'ppc64le'
 if node['travis_packer_templates']['env']['PACKER_BUILDER_TYPE'] == 'docker'
@@ -65,4 +64,5 @@ include_recipe 'travis_phantomjs::2'
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'
 
+include_recipe 'travis_packer_templates'
 include_recipe 'travis_system_info'

--- a/cookbooks/travis_ci_opal/recipes/default.rb
+++ b/cookbooks/travis_ci_opal/recipes/default.rb
@@ -25,6 +25,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 include_recipe 'travis_build_environment::apt'
+include_recipe 'travis_packer_templates::bootstrap'
 include_recipe 'travis_build_environment'
 include_recipe 'travis_build_environment::haskell' if node['kernel']['machine'] != 'ppc64le'
 if node['travis_packer_templates']['env']['PACKER_BUILDER_TYPE'] == 'docker'
@@ -64,5 +65,5 @@ include_recipe 'travis_phantomjs::2'
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'
 
-include_recipe 'travis_packer_templates'
+include_recipe 'travis_packer_templates::finalize'
 include_recipe 'travis_system_info'

--- a/cookbooks/travis_ci_sardonyx/recipes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/recipes/default.rb
@@ -25,6 +25,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 include_recipe 'travis_build_environment::apt'
+include_recipe 'travis_packer_templates::bootstrap'
 include_recipe 'travis_build_environment'
 
 if node['travis_packer_templates']['env']['PACKER_BUILDER_TYPE'] == 'docker'
@@ -67,7 +68,7 @@ include_recipe 'travis_phantomjs::2'
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'
 
-include_recipe 'travis_packer_templates'
+include_recipe 'travis_packer_templates::finalize'
 include_recipe 'travis_system_info'
 
 # HACK: force removal of ~/.pearrc until a decision is reached on if they are

--- a/cookbooks/travis_ci_sardonyx/recipes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/recipes/default.rb
@@ -25,7 +25,6 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 include_recipe 'travis_build_environment::apt'
-include_recipe 'travis_packer_templates'
 include_recipe 'travis_build_environment'
 
 if node['travis_packer_templates']['env']['PACKER_BUILDER_TYPE'] == 'docker'
@@ -68,6 +67,7 @@ include_recipe 'travis_phantomjs::2'
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'
 
+include_recipe 'travis_packer_templates'
 include_recipe 'travis_system_info'
 
 # HACK: force removal of ~/.pearrc until a decision is reached on if they are

--- a/cookbooks/travis_ci_stevonnie/recipes/default.rb
+++ b/cookbooks/travis_ci_stevonnie/recipes/default.rb
@@ -25,7 +25,6 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 include_recipe 'travis_build_environment::apt'
-include_recipe 'travis_packer_templates'
 include_recipe 'travis_build_environment'
 
 if node['travis_packer_templates']['env']['PACKER_BUILDER_TYPE'] == 'docker'
@@ -51,6 +50,7 @@ include_recipe 'travis_postgresql::pgdg'
 # HACK: stevonnie-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'
 
+include_recipe 'travis_packer_templates'
 include_recipe 'travis_system_info'
 
 # HACK: force removal of ~/.pearrc until a decision is reached on if they are

--- a/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
+++ b/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
@@ -7,14 +7,13 @@ require 'fileutils'
 require 'chef'
 
 class TravisPackerTemplates
-  attr_reader :node, :init_time
+  attr_reader :node
 
   def initialize(node)
     @node = node
   end
 
   def init!(init_time)
-    @init_time = init_time
     node.override['__timestamp'] = init_time
     import_packer_env_vars
     assign_travis_system_info_cookbooks_sha(
@@ -61,7 +60,7 @@ class TravisPackerTemplates
     tags = {
       'dist' => node['lsb']['codename'].to_s,
       'os' => node['os'].to_s,
-      'packer_chef_time' => init_time.strftime('%Y%m%dT%H%M%SZ')
+      'packer_chef_time' => packer_chef_time
     }
 
     %w[language feature].each do |prefix|
@@ -71,6 +70,10 @@ class TravisPackerTemplates
     end
 
     tags
+  end
+
+  def packer_chef_time
+    node['__init_time'].strftime('%Y%m%dT%H%M%SZ')
   end
 
   def lil_hash(hash)

--- a/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
+++ b/cookbooks/travis_packer_templates/libraries/travis_packer_templates.rb
@@ -11,11 +11,11 @@ class TravisPackerTemplates
 
   def initialize(node)
     @node = node
-    @init_time = Time.now.utc
   end
 
   def init!(init_time)
     @init_time = init_time
+    node.override['__timestamp'] = init_time
     import_packer_env_vars
     assign_travis_system_info_cookbooks_sha(
       node['travis_packer_templates']['env']['TRAVIS_COOKBOOKS_SHA'].to_s
@@ -34,7 +34,7 @@ class TravisPackerTemplates
 
     write_yml(
       node['travis_packer_templates']['node_attributes_yml'],
-      node_attributes_hash.merge('__timestamp' => init_time.to_s)
+      node_attributes_hash
     )
   end
 

--- a/cookbooks/travis_packer_templates/recipes/default.rb
+++ b/cookbooks/travis_packer_templates/recipes/default.rb
@@ -64,13 +64,3 @@ Array(node['travis_packer_templates']['packages']).each_slice(10) do |slice|
     action %i[install upgrade]
   end
 end
-
-%w[
-  apt-daily-upgrade.service
-  apt-daily-upgrade.timer
-  apt-daily.service
-  apt-daily.timer
-].each do |unit|
-  execute "systemctl disable #{unit}"
-  execute "systemctl stop #{unit}"
-end

--- a/cookbooks/travis_packer_templates/recipes/finalize.rb
+++ b/cookbooks/travis_packer_templates/recipes/finalize.rb
@@ -24,11 +24,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-init_time = Time.now.utc
 travis_packer_templates = nil
 travis_packer_templates = TravisPackerTemplates.new(node) if
   defined?(TravisPackerTemplates)
-travis_packer_templates&.init!(init_time)
 
 template '/etc/profile.d/Z90-travis-packer-templates.sh' do
   source 'etc-profile-d-travis-packer-templates.sh.erb'
@@ -40,7 +38,7 @@ template '/etc/profile.d/Z90-travis-packer-templates.sh' do
     features: node['travis_packer_templates']['job_board']['features'],
     languages: node['travis_packer_templates']['job_board']['languages'],
     stack: node['travis_packer_templates']['job_board']['stack'],
-    timestamp: init_time
+    timestamp: node['__timestamp']
   )
 end
 
@@ -55,12 +53,4 @@ end
 
 ruby_block 'write job-board registration bits' do
   block { travis_packer_templates.write_job_board_register_yml }
-end
-
-Array(node['travis_packer_templates']['packages']).each_slice(10) do |slice|
-  apt_package slice do
-    retries 2
-    options '--no-install-recommends --no-install-suggests'
-    action %i[install upgrade]
-  end
 end


### PR DESCRIPTION
Job board metadata the possibility of being changed during the run of the recipes. This change ensures that the metadata is written after the recipes have run.