### PR TITLE
Serverspecs: Assume Elasticsearch is running already

### DIFF
--- a/packer-assets/opal-system-info-commands.yml
+++ b/packer-assets/opal-system-info-commands.yml
@@ -117,12 +117,10 @@ commands:
   - command: couchdb -V
     name: CouchDB version
     pipe: perl -n -e '/CouchDB ([\d\.]+)/ && {print "couchdb $1\n"}'
-  - pre: sudo systemctl restart elasticsearch; sleep 30
-    name: ElasticSearch version
+  - name: ElasticSearch version
     port: 9200
-    command: curl localhost:9200 2>/dev/null
+    command: curl localhost:9200
     pipe: awk -F\" '/number/ { print $4 }'
-    post: sudo systemctl stop elasticsearch >/dev/null
   - command: ls -d /usr/local/firefox-*
     name: Installed Firefox version
     pipe: awk -F- '{print "firefox", $2}'

--- a/packer-assets/sardonyx-system-info-commands.yml
+++ b/packer-assets/sardonyx-system-info-commands.yml
@@ -117,12 +117,10 @@ commands:
   - command: couchdb -V
     name: CouchDB version
     pipe: perl -n -e '/CouchDB ([\d\.]+)/ && {print "couchdb $1\n"}'
-  - pre: sudo systemctl restart elasticsearch; sleep 30
-    name: ElasticSearch version
+  - name: ElasticSearch version
     port: 9200
-    command: curl localhost:9200 2>/dev/null
+    command: curl localhost:9200
     pipe: awk -F\" '/number/ { print $4 }'
-    post: sudo systemctl stop elasticsearch >/dev/null
   - command: ls -d /usr/local/firefox-*
     name: Installed Firefox version
     pipe: awk -F- '{print "firefox", $2}'

--- a/packer-assets/system-info.d/elasticsearch.yml
+++ b/packer-assets/system-info.d/elasticsearch.yml
@@ -1,8 +1,6 @@
 commands:
   common:
-    - pre: "sudo systemctl restart elasticsearch; sleep 30"
-      name: ElasticSearch version
+    - name: ElasticSearch version
       port: 9200
-      command: 'curl localhost:9200 2>/dev/null'
+      command: curl localhost:9200
       pipe: "awk -F\\\" '/number/ { print $4 }'"
-      post: sudo systemctl stop elasticsearch >/dev/null


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Serverspec failures on the docker builder relating to the elasticsearch socket being unreachable

## What approach did you choose and why?
By lack of a better idea, do not restart the elasticsearch service, but rely on it being active

## How can you test this?
Watch the image builds go green

## What feedback would you like, if any?
