### PR TITLE
Defer job board feature determination with help of chef

### DIFF
--- a/cookbooks/travis_ci_opal/recipes/default.rb
+++ b/cookbooks/travis_ci_opal/recipes/default.rb
@@ -65,4 +65,12 @@ include_recipe 'travis_phantomjs::2'
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'
 
+log 'trigger writing node attributes' do
+  notifies :run, 'ruby_block[write node attributes]'
+end
+
+log 'trigger job-board registration' do
+  notifies :run, 'ruby_block[write job-board registration bits]'
+end
+
 include_recipe 'travis_system_info'

--- a/cookbooks/travis_ci_sardonyx/recipes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/recipes/default.rb
@@ -68,6 +68,14 @@ include_recipe 'travis_phantomjs::2'
 # HACK: sardonyx-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'
 
+log 'trigger writing node attributes' do
+  notifies :run, 'ruby_block[write node attributes]'
+end
+
+log 'trigger job-board registration' do
+  notifies :run, 'ruby_block[write job-board registration bits]'
+end
+
 include_recipe 'travis_system_info'
 
 # HACK: force removal of ~/.pearrc until a decision is reached on if they are

--- a/cookbooks/travis_ci_stevonnie/recipes/default.rb
+++ b/cookbooks/travis_ci_stevonnie/recipes/default.rb
@@ -51,6 +51,14 @@ include_recipe 'travis_postgresql::pgdg'
 # HACK: stevonnie-specific shims!
 execute 'ln -svf /usr/bin/hashdeep /usr/bin/md5deep'
 
+log 'trigger writing node attributes' do
+  notifies :run, 'ruby_block[write node attributes]'
+end
+
+log 'trigger job-board registration' do
+  notifies :run, 'ruby_block[write job-board registration bits]'
+end
+
 include_recipe 'travis_system_info'
 
 # HACK: force removal of ~/.pearrc until a decision is reached on if they are

--- a/cookbooks/travis_packer_templates/recipes/default.rb
+++ b/cookbooks/travis_packer_templates/recipes/default.rb
@@ -49,12 +49,9 @@ ruby_block 'write node attributes' do
   action :nothing
 end
 
-log 'trigger writing node attributes' do
-  notifies :run, 'ruby_block[write node attributes]'
-end
-
 ruby_block 'write job-board registration bits' do
   block { travis_packer_templates.write_job_board_register_yml }
+  action :nothing
 end
 
 Array(node['travis_packer_templates']['packages']).each_slice(10) do |slice|
@@ -63,14 +60,4 @@ Array(node['travis_packer_templates']['packages']).each_slice(10) do |slice|
     options '--no-install-recommends --no-install-suggests'
     action %i[install upgrade]
   end
-end
-
-%w[
-  apt-daily-upgrade.service
-  apt-daily-upgrade.timer
-  apt-daily.service
-  apt-daily.timer
-].each do |unit|
-  execute "systemctl disable #{unit}"
-  execute "systemctl stop #{unit}"
 end


### PR DESCRIPTION
Supersedes #670 
Job board metadata the possibility of being changed during the run of the recipes. This change ensures that the metadata is written after the recipes have run.