### PR TITLE
Get insights on durations, and decrease apt time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ TRAVIS_PACKER_BUILD ?= travis-packer-build
 UNZIP ?= unzip
 
 %: %.yml $(META_FILES)
-	$(PACKER) build -only=$(BUILDER) <(bin/yml2json < $<)
+	$(PACKER) build -only=$(BUILDER) -timestamp-ui <(bin/yml2json < $<)
 
 .PHONY: all
 all: $(META_FILES) $(PHP_PACKAGES_FILE) $(SYSTEM_INFO_COMMANDS_FILES)

--- a/cookbooks/travis_packer_templates/recipes/default.rb
+++ b/cookbooks/travis_packer_templates/recipes/default.rb
@@ -58,6 +58,6 @@ Array(node['travis_packer_templates']['packages']).each_slice(10) do |slice|
   apt_package slice do
     retries 2
     options '--no-install-recommends --no-install-suggests'
-    action %i[install upgrade]
+    action :install
   end
 end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
This is to get some more insight in the build time. By passing `-timestamp-ui` to `packer build`, we'll get some timing information in the logs. Can easily be disabled when this turns out to be to noisy.

Apart from that, the `apt-get install` of the package list drops `upgrade`. This will save an extra apt process for each slice that is actioned. To cater for packages that are already installed and could use an upgrade, https://github.com/travis-ci/travis-cookbooks/pull/1029 has been created.

## What approach did you choose and why?

## How can you test this?

## What feedback would you like, if any?
