### PR TITLE
Include perl6

### DIFF
--- a/cookbooks/travis_ci_opal/attributes/default.rb
+++ b/cookbooks/travis_ci_opal/attributes/default.rb
@@ -146,6 +146,7 @@ override['travis_packer_templates']['job_board']['languages'] = %w[
   haxe
   julia
   perl
+  perl6
   r
   rust
 ]


### PR DESCRIPTION
Perl6 jobs were not routed to xenial images. This PR adds the appropriate metadata to the image so the resulting image can be selected.