### PR TITLE
Update FreeBSD template

### DIFF
--- a/ci-freebsd-12.yml
+++ b/ci-freebsd-12.yml
@@ -48,6 +48,7 @@ provisioners:
   - packer-scripts/freebsd-update
   - packer-scripts/pre-chef-bootstrap-bsd
   - packer-scripts/clone-travis-cookbooks-bsd
+  - packer-scripts/freebsd-install-pkgs
   - packer-scripts/freebsd-cleanup
   environment_vars:
   - TRAVIS_COOKBOOKS_BRANCH={{ user `travis_cookbooks_branch` }}

--- a/packer-scripts/freebsd-install-pkgs
+++ b/packer-scripts/freebsd-install-pkgs
@@ -1,0 +1,15 @@
+#!/bin/csh -xe
+
+pkg install -y bash
+pkg install -y gcc10-devel cmake gmake gnulib autoconf automake ccache
+
+ln -s /usr/local/bin/gcc10 /usr/local/bin/gcc
+ln -s /usr/local/bin/g++10 /usr/local/bin/g++
+
+pkg install -y openjdk8
+pkg install -y openjdk11
+pkg install -y openjdk12
+pkg install -y openjdk13
+pkg install -y maven
+pkg install -y gradle
+pkg install -y apache-ant


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
There is no problem. It's an image development.

What we did?
- added file freebsd-install-pkgs to packer-templates/packer-scripts
- changed packer-templates/ci-freebsd-12.yml - added line to provisioners' shell subsection that launches script file freebsd-install-pkgs
- the script adds to FreeBSD image new packages (with required dependencies): 
   - bash
   - gcc10-devel, cmake, gmake, gnulib, autoconf, automake, ccache
   - openjdk8, openjdk11, openjdk12, openjdk13
   - maven, gradle, apache-ant
- the script also creates symbolic links for C and C++ proper versions
   

## What approach did you choose and why?

## How can you test this?

Test with simple "hello world" in java (each added version), C and C++

## What feedback would you like, if any?

If "hello world" worked for each language and version