### PR TITLE
Checking the correct lxd xenial/bionic images

### DIFF
--- a/lxd/ubuntu-16.04-full.yml
+++ b/lxd/ubuntu-16.04-full.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu/xenial
+  image: images:ubuntu:xenial
   output_image: ubuntu-16.04-full-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 16.04 Full build env template!

--- a/lxd/ubuntu-16.04-generic.yml
+++ b/lxd/ubuntu-16.04-generic.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu/xenial
+  image: images:ubuntu:xenial
   output_image: ubuntu-16.04-generic-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 16.04 generic build env template!

--- a/lxd/ubuntu-16.04-minimal.yml
+++ b/lxd/ubuntu-16.04-minimal.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu/xenial
+  image: images:ubuntu:xenial
   output_image: ubuntu-16.04-minimal-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 16.04 Minimal build env template!

--- a/lxd/ubuntu-16.04-slim.yml
+++ b/lxd/ubuntu-16.04-slim.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu/xenial
+  image: images:ubuntu:xenial
   output_image: ubuntu-16.04-slim-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 16.04 Slim build env template!

--- a/lxd/ubuntu-18.04-full.yml
+++ b/lxd/ubuntu-18.04-full.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu/18.04
+  image: images:ubuntu:18.04
   output_image: ubuntu-18.04-full-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 18.04 Full build env template!

--- a/lxd/ubuntu-18.04-generic.yml
+++ b/lxd/ubuntu-18.04-generic.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu/18.04
+  image: images:ubuntu:18.04
   output_image: ubuntu-18.04-generic-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 18.04 generic build env template!

--- a/lxd/ubuntu-18.04-minimal.yml
+++ b/lxd/ubuntu-18.04-minimal.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu/18.04
+  image: images:ubuntu:18.04
   output_image: ubuntu-18.04-minimal-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 18.04 Minimal build env template!

--- a/lxd/ubuntu-18.04-slim.yml
+++ b/lxd/ubuntu-18.04-slim.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu/18.04
+  image: images:ubuntu:18.04
   output_image: ubuntu-18.04-slim-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 18.04 Slim build env template!


### PR DESCRIPTION
Existing logic was "ubuntu/xenial" , here "/" needs to change to ":"

## What is the problem that this PR is trying to fix?
Using the correct symbol to download lxd image ( for xenial and bionic tags )

## What approach did you choose and why?
Used to always get this message "The local image 'ubuntu/18.04' couldn't be found, trying 'ubuntu:18.04' instead." . So to ensure this is suppressed  , used ":" insteal of "/" in full, generic , minimal and slim image yaml's

## How can you test this?
```
[root@p006n04 lxd]# lxc launch ubuntu/18.04 myc2
Creating myc2
The local image 'ubuntu/18.04' couldn't be found, trying 'ubuntu:18.04' instead.
Starting myc2

[root@p006n04 lxd]# lxc launch ubuntu:18.04 myc3
Creating myc3
Starting myc3

```
## What feedback would you like, if any?
None