### PR TITLE
fixed image download issue

### DIFF
--- a/lxd/ubuntu-16.04-full.yml
+++ b/lxd/ubuntu-16.04-full.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu:xenial
+  image: ubuntu:xenial
   output_image: ubuntu-16.04-full-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 16.04 Full build env template!

--- a/lxd/ubuntu-16.04-generic.yml
+++ b/lxd/ubuntu-16.04-generic.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu:xenial
+  image: ubuntu:xenial
   output_image: ubuntu-16.04-generic-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 16.04 generic build env template!

--- a/lxd/ubuntu-16.04-minimal.yml
+++ b/lxd/ubuntu-16.04-minimal.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu:xenial
+  image: ubuntu:xenial
   output_image: ubuntu-16.04-minimal-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 16.04 Minimal build env template!

--- a/lxd/ubuntu-16.04-slim.yml
+++ b/lxd/ubuntu-16.04-slim.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu:xenial
+  image: ubuntu:xenial
   output_image: ubuntu-16.04-slim-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 16.04 Slim build env template!

--- a/lxd/ubuntu-18.04-full.yml
+++ b/lxd/ubuntu-18.04-full.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu:18.04
+  image: ubuntu:18.04
   output_image: ubuntu-18.04-full-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 18.04 Full build env template!

--- a/lxd/ubuntu-18.04-generic.yml
+++ b/lxd/ubuntu-18.04-generic.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu:18.04
+  image: ubuntu:18.04
   output_image: ubuntu-18.04-generic-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 18.04 generic build env template!

--- a/lxd/ubuntu-18.04-minimal.yml
+++ b/lxd/ubuntu-18.04-minimal.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu:18.04
+  image: ubuntu:18.04
   output_image: ubuntu-18.04-minimal-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 18.04 Minimal build env template!

--- a/lxd/ubuntu-18.04-slim.yml
+++ b/lxd/ubuntu-18.04-slim.yml
@@ -9,7 +9,7 @@ variables:
 builders:
 - type: lxd
   name: lxd-{{ uuid }}
-  image: images:ubuntu:18.04
+  image: ubuntu:18.04
   output_image: ubuntu-18.04-slim-{{user `image_time`}}
   publish_properties:
    - description: Travis CI Ubuntu 18.04 Slim build env template!


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
To ensure lxd base image get downloaded , removed "images" string as part of builders
Post this PR -https://github.com/travis-ci/packer-templates/pull/760 , was getting below error during build process
```
==> lxd-5e556d97-fe22-9a40-bd4e-328cd3e6bf05: Error deleting container: LXD command error: Error: not found
Build 'lxd-5e556d97-fe22-9a40-bd4e-328cd3e6bf05' errored: Error creating container: LXD command error: Error: Failed instance creation: The requested image couldn't be found
```

## What approach did you choose and why?
To ensure lxd base image get downloaded , removed "images" string as part of builders
## How can you test this?

## What feedback would you like, if any?
