### PR TITLE
Calculate SHA256 sum on exported LXC image file

### DIFF
--- a/bin/lxc-export.sh
+++ b/bin/lxc-export.sh
@@ -14,5 +14,5 @@ done
 lxc image export "${IMAGE_NAME}" /home/travis/"${IMAGE_NAME}"
 aws s3 cp /home/travis/"${IMAGE_NAME}".tar.gz s3://"${LXC_AWS_BUCKET}"/amd64/
 
-sha256 /home/travis/"${IMAGE_NAME}".tar.gz > /home/travis/"${IMAGE_NAME}"_checksum.txt
+sha256sum /home/travis/"${IMAGE_NAME}".tar.gz > /home/travis/"${IMAGE_NAME}"_checksum.txt
 aws s3 cp /home/travis/"${IMAGE_NAME}"_checksum.txt s3://"${LXC_AWS_BUCKET}"/amd64/

--- a/bin/lxc-export.sh
+++ b/bin/lxc-export.sh
@@ -14,5 +14,5 @@ done
 lxc image export "${IMAGE_NAME}" /home/travis/"${IMAGE_NAME}"
 aws s3 cp /home/travis/"${IMAGE_NAME}".tar.gz s3://"${LXC_AWS_BUCKET}"/amd64/
 
-sha256sum /home/travis/"${IMAGE_NAME}".tar.gz > /home/travis/"${IMAGE_NAME}"_checksum.txt
+sha256sum /home/travis/"${IMAGE_NAME}".tar.gz | cut -f1 -d ' ' > /home/travis/"${IMAGE_NAME}"_checksum.txt
 aws s3 cp /home/travis/"${IMAGE_NAME}"_checksum.txt s3://"${LXC_AWS_BUCKET}"/amd64/

--- a/bin/lxc-export.sh
+++ b/bin/lxc-export.sh
@@ -12,5 +12,7 @@ while ! lxc image ls | grep -q "${IMAGE_NAME}"; do
 done
 
 lxc image export "${IMAGE_NAME}" /home/travis/"${IMAGE_NAME}"
-
 aws s3 cp /home/travis/"${IMAGE_NAME}".tar.gz s3://"${LXC_AWS_BUCKET}"/amd64/
+
+sha256 /home/travis/"${IMAGE_NAME}".tar.gz > /home/travis/"${IMAGE_NAME}"_checksum.txt
+aws s3 cp /home/travis/"${IMAGE_NAME}"_checksum.txt s3://"${LXC_AWS_BUCKET}"/amd64/


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
We need to have sha256 checksums of LXC images for images server

## What approach did you choose and why?
Calculate sha256 on the image file and upload to S3

## How can you test this?

## What feedback would you like, if any?
