### PR TITLE
Update lxc-export.sh

### DIFF
--- a/bin/lxc-export.sh
+++ b/bin/lxc-export.sh
@@ -12,7 +12,7 @@ while ! lxc image ls | grep -q "${IMAGE_NAME}"; do
 done
 
 lxc image export "${IMAGE_NAME}" /home/travis/"${IMAGE_NAME}"
-aws s3 cp /home/travis/"${IMAGE_NAME}".tar.gz s3://"${LXC_AWS_BUCKET}"/amd64/
+aws s3 cp /home/travis/"${IMAGE_NAME}".tar.gz s3://"${LXC_AWS_BUCKET}"/amd64/ --acl public-read
 
 sha256sum /home/travis/"${IMAGE_NAME}".tar.gz | cut -f1 -d ' ' > /home/travis/"${IMAGE_NAME}"_checksum.txt
-aws s3 cp /home/travis/"${IMAGE_NAME}"_checksum.txt s3://"${LXC_AWS_BUCKET}"/amd64/
+aws s3 cp /home/travis/"${IMAGE_NAME}"_checksum.txt s3://"${LXC_AWS_BUCKET}"/amd64/ --acl public-read


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Uploaded LXC images should be publicly accessible
## What approach did you choose and why?
`--acl public-read`
## How can you test this?

## What feedback would you like, if any?
