### PR TITLE
Boldly updating freebsd to 12.1

### DIFF
--- a/ci-freebsd-12.yml
+++ b/ci-freebsd-12.yml
@@ -23,7 +23,7 @@ builders:
   account_file: "{{ user `gce_account_file` }}"
   project_id: "{{ user `gce_project_id` }}"
   source_image_project_id: freebsd-org-cloud-dev
-  source_image: freebsd-12-0-release-amd64
+  source_image: freebsd-12-1-release-amd64
   zone: us-central1-a
   image_name: "{{ user `image_name` }}"
   machine_type: n1-standard-4


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Using EoL FreeBSD image

## What approach did you choose and why?
Boldly updating to newest version and checking if rest of scripts run correctly. The 12.0 is EOL already since November 2019

## How can you test this?
Provision a new image and see if it works. Requires certain access rights Travis CI crew has.

## What feedback would you like, if any?
