### PR TITLE
Update ci-ubuntu-2004-packages.txt

### DIFF
--- a/packer-assets/ci-ubuntu-2004-packages.txt
+++ b/packer-assets/ci-ubuntu-2004-packages.txt
@@ -129,7 +129,6 @@ libncursesw5-dev
 libossp-uuid-dev
 libpng-dev
 libpq-dev
-libqt4-dev
 libreadline-dev
 libsasl2-dev
 libsqlite3-dev


### PR DESCRIPTION
Problem occuring during the package installation : libqt4-dev
It looks, that  ubuntu doesn't support qt4 in focal release : https://packages.ubuntu.com/search?suite=focal&arch=any&searchon=names&keywords=libqt4

## What is the problem that this PR is trying to fix?
ubuntu-2004 GCE image creation 
## What approach did you choose and why?

## How can you test this?

## What feedback would you like, if any?
