### PR TITLE
qt4-qmake

### DIFF
--- a/packer-assets/ci-ubuntu-2004-packages.txt
+++ b/packer-assets/ci-ubuntu-2004-packages.txt
@@ -202,7 +202,6 @@ python3-problem-report
 python3-pycurl
 python3-software-properties
 python3-update-manager
-qt4-qmake
 ragel
 re2c
 readline-common


### PR DESCRIPTION
Problem occuring during the package installation : qt4-qmake
It looks, that  ubuntu doesn't support qt4 in focal release : https://packages.ubuntu.com/search?suite=focal&arch=any&searchon=names&keywords=qt4

## What is the problem that this PR is trying to fix?

## What approach did you choose and why?

## How can you test this?

## What feedback would you like, if any?
