### PR TITLE
add R language to 1804 job board

### DIFF
--- a/cookbooks/travis_ci_ubuntu_1804/attributes/default.rb
+++ b/cookbooks/travis_ci_ubuntu_1804/attributes/default.rb
@@ -187,6 +187,7 @@ override['travis_packer_templates']['job_board']['languages'] = %w[
   php
   pure_java
   python
+  r
   ruby
   scala
   julia


### PR DESCRIPTION
language: r, dist: bionic was routed to xenial image instead of bionic. 