### PR TITLE
Fix JDK installation in lxd images

### DIFF
--- a/lxd/scripts/jvm.sh
+++ b/lxd/scripts/jvm.sh
@@ -18,8 +18,9 @@ __install_packages() {
 }
 
 __install_java(){
+  . /etc/os-release
   wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
-  sudo add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+  echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ ${VERSION_CODENAME} main" | tee /etc/apt/sources.list.d/adoptopenjdk.list
   rm -rf /var/lib/apt/lists/*
   apt-get update -yqq
   apt-get -yqq --no-install-suggests --no-install-recommends install adoptopenjdk-${JAVA_VERSION}-hotspot

--- a/lxd/scripts/jvm.sh
+++ b/lxd/scripts/jvm.sh
@@ -27,7 +27,13 @@ __install_java(){
 }
 
 __install_maven(){
-  apt-get -yqq --no-install-suggests --no-install-recommends install maven
+  mkdir -p /opt/mvn
+  curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz|tar -xz --strip 1 -C /opt/mvn
+
+  echo 'export MAVEN_HOME=/opt/mvn
+  export PATH=${MAVEN_HOME}/bin:${PATH}' > /home/travis/.bash_profile.d/mvn.bash
+  chmod 644 /home/travis/.bash_profile.d/mvn.bash
+  chown travis: /home/travis/.bash_profile.d/mvn.bash
 }
 
 main "$@"


### PR DESCRIPTION
This PR fixes #813

> 1. Default jdk removal failure due to dependencies

This issue is resolved by changing the maven installation method from apt to tarball.

> 2. Unable to find adoptopenjdk packages.

To resolve this issue, adoptopenjdk repos are added into `/etc/apt/sources.list.d/` directory so that `sources.list` file override doesn't affect the repos. 