### PR TITLE
Fix sardonyx image build on ppc64le

### DIFF
--- a/ci-sardonyx.yml
+++ b/ci-sardonyx.yml
@@ -69,7 +69,7 @@ builders:
 # https://github.com/travis-ci/packer-templates/issues/555
 - type: openstack
   name: openstack
-  flavor: m1.large
+  flavor: p9.large
   insecure: true
   image_name: "{{ user `image_name` }}"
   ssh_username: ubuntu

--- a/cookbooks/travis_ci_sardonyx/attributes/default.rb
+++ b/cookbooks/travis_ci_sardonyx/attributes/default.rb
@@ -44,7 +44,6 @@ override['travis_build_environment']['gimme']['default_version'] = gimme_version
 
 if node['kernel']['machine'] == 'ppc64le'
   override['travis_java']['default_version'] = 'openjdk8'
-  override['travis_java']['alternate_versions'] = %w[openjdk7]
 else
   override['travis_jdk']['versions'] = %w[
     openjdk10

--- a/packer-scripts/run-serverspecs
+++ b/packer-scripts/run-serverspecs
@@ -8,9 +8,6 @@ main() {
 
   export CHEF_PATH='/opt/chef-workstation/bin:/opt/chef-workstation/embedded/bin:/opt/chef/bin'
 
-  if [[ "$(uname -m)" =~ ppc64 ]]; then
-    export CHEF_PATH=$CHEF_PATH:/opt/chef-workstation/embedded/bin
-  fi
   export CHEF_LICENSE='accept-silent'
   export PATH="$CHEF_PATH:$PATH"
   export DEBIAN_FRONTEND='noninteractive'
@@ -22,8 +19,10 @@ main() {
     export SPEC_ARGS="${SPEC_ARGS} --tag ~docker:false"
   fi
 
-  if [[ "$(uname -m)" =~ ppc64|aarch64 ]]; then
+  if [[ "$(uname -m)" =~ aarch64 ]]; then
     __install_serverspec
+  elif [[ "$(uname -m)" =~ ppc64 ]]; then
+    __install_serverspec_ppc64le
   else
     __install_chef "${PACKER_CHEF_PREFIX}"
   fi
@@ -43,6 +42,10 @@ main() {
 
 __install_serverspec() {
   chef gem install serverspec
+}
+
+__install_serverspec_ppc64le() {
+  gem install serverspec
 }
 
 __install_chef() {
@@ -114,15 +117,26 @@ export PATH=\"${CHEF_PATH}:\$PATH\"
 export TERM=xterm
 export PACKER_BUILDER_TYPE=${PACKER_BUILDER_TYPE}
 export RUBYOPT=${RUBYOPT}
-chef gem install serverspec
+if [[ "$(uname -m)" =~ ppc64 ]]; then
+  gem install serverspec
+else
+  chef gem install serverspec
+fi
 unset GEM_PATH
 cd ${cookbook_dir}
 sudo systemctl start xvfb.service
 set -o errexit
-chef exec rspec ${SPEC_ARGS} \\
-  --format documentation \\
-  --format json \\
-  --out /home/travis/.${suite}_rspec.json
+if [[ "$(uname -m)" =~ ppc64 ]]; then
+  rspec ${SPEC_ARGS} \\
+    --format documentation \\
+    --format json \\
+    --out /home/travis/.${suite}_rspec.json
+else
+  chef exec rspec ${SPEC_ARGS} \\
+    --format documentation \\
+    --format json \\
+    --out /home/travis/.${suite}_rspec.json
+fi
 "
 
   local exit_code="$?"

--- a/packer-scripts/run-serverspecs
+++ b/packer-scripts/run-serverspecs
@@ -117,7 +117,7 @@ export PATH=\"${CHEF_PATH}:\$PATH\"
 export TERM=xterm
 export PACKER_BUILDER_TYPE=${PACKER_BUILDER_TYPE}
 export RUBYOPT=${RUBYOPT}
-if [[ "$(uname -m)" =~ ppc64 ]]; then
+if [[ $(uname -m) =~ ppc64 ]]; then
   gem install serverspec
 else
   chef gem install serverspec
@@ -126,7 +126,7 @@ unset GEM_PATH
 cd ${cookbook_dir}
 sudo systemctl start xvfb.service
 set -o errexit
-if [[ "$(uname -m)" =~ ppc64 ]]; then
+if [[ $(uname -m) =~ ppc64 ]]; then
   rspec ${SPEC_ARGS} \\
     --format documentation \\
     --format json \\


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Fix sardonyx image build on ppc64le
- `m1` openstack flavor is replaced with `p9`
- `openjdk7` is no longer available via `apt install` on ppc64le
- `chef cli` is not available on ppc64le
## What approach did you choose and why?
- Update openstack machine flavor
- Remove `openjdk7` install on ppc64le
- Skip usage of `chef` cli to run serverspec on ppc64le


