### PR TITLE
Update install-docker.sh to set mtu value

### DIFF
--- a/lxd/scripts/install-docker.sh
+++ b/lxd/scripts/install-docker.sh
@@ -8,6 +8,11 @@ chmod +x /usr/sbin/policy-rc.d
 apt-get install -y docker.io pigz --no-install-recommends
 rm -f /usr/sbin/policy-rc.d
 mkdir -p /etc/docker
-
+if [[ $(arch) == "ppc64le" ]]
+then
+  #Update docker mtu to 1460
+  echo '{"mtu": 1460}' > /tmp/daemon.json
+  sudo cp -f /tmp/daemon.json /etc/docker/daemon.json
+fi
 # add travis to docker group
 id travis && usermod -aG docker travis


### PR DESCRIPTION
Update install-docker.sh to set mtu value in /etc/docker/daemon.json.
Setting docker mtu value. docker container mtu should be less than or equal to host mtu. It should not be more than host mtu. In case, where docker container mtu is greater than host mtu. curl downloads are failed.

## What is the problem that this PR is trying to fix?
docker container mtu should be less than or equal to host mtu. It should not be more than host mtu. In case, where docker container mtu is greater than host mtu. curl downloads are failed

## What approach did you choose and why?
Setting mtu value in file /etc/docker/daemon.json. So that, docker container mtu will be less than or equal to host mtu.

## How can you test this?
It can be tested by downloading file from jfrog using curl command. It will fail to download because of mtu different in docker and host.

## What feedback would you like, if any?
It can be fixed in base image.