### PR TITLE
Increase default Python3.8 versions for Focal

### DIFF
--- a/cookbooks/travis_ci_ubuntu_2004/attributes/default.rb
+++ b/cookbooks/travis_ci_ubuntu_2004/attributes/default.rb
@@ -13,7 +13,7 @@ override['travis_build_environment']['python_aliases'] = {
 # packages build by Cpython + our repo
 pythons = %w[
   3.7.7
-  3.8.3
+  3.8.13
   3.9.0
 ]
 override['travis_build_environment']['pythons'] = pythons


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Increasing the default Python3.8 version for Focal image
## What approach did you choose and why?
Changing the from Python version 3.8.3 to 3.8.13
## How can you test this?
Running test builds with `python: 3.8` within .travis.yml file.
## What feedback would you like, if any?
