### PR TITLE
Fixing MongoDB version for Focal, set preinstalled openjdk9 and use ruby 2.7

### DIFF
--- a/cookbooks/lib/features/mongodb_spec.rb
+++ b/cookbooks/lib/features/mongodb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 def mongodb_service_name
-  return 'mongod' if %w[trusty xenial bionic].include?(Support.distro) && os[:arch] !~ /ppc64/
+  return 'mongod' if %w[trusty xenial bionic focal jammy].include?(Support.distro) && os[:arch] !~ /ppc64/
 
   'mongodb'
 end

--- a/cookbooks/travis_ci_ubuntu_1804/attributes/default.rb
+++ b/cookbooks/travis_ci_ubuntu_1804/attributes/default.rb
@@ -70,6 +70,7 @@ if node['kernel']['machine'] == 'ppc64le'
 else
   override['travis_jdk']['versions'] = %w[
     openjdk8
+    openjdk9
     openjdk10
     openjdk11
   ]

--- a/cookbooks/travis_ci_ubuntu_2004/attributes/default.rb
+++ b/cookbooks/travis_ci_ubuntu_2004/attributes/default.rb
@@ -68,6 +68,7 @@ elsif node['kernel']['machine'] == 'aarch64'
     'e08c9542ff6cb231dd03d6f8096f6749e79056734bf69d5399205451b94c9d03'
 else
   override['travis_jdk']['versions'] = %w[
+    openjdk9
     openjdk10
     openjdk11
   ]
@@ -99,7 +100,7 @@ rubies = %w[
 
 override['travis_build_environment']['virtualenv']['version'] = '20.0.20'
 
-override['travis_build_environment']['default_ruby'] = rubies.reject { |n| n =~ /jruby/ }.max
+override['travis_build_environment']['default_ruby'] = '2.7.6'
 override['travis_build_environment']['rubies'] = rubies
 
 override['travis_build_environment']['otp_releases'] = %w[


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Fixing MongoDB version for Focal, set preinstalled openjdk9 and use ruby 2.7
## What approach did you choose and why?

## How can you test this?

## What feedback would you like, if any?
